### PR TITLE
fix(ci): restore 'jobs' key in 04-build-site.yml (workflow parse error)

### DIFF
--- a/.github/workflows/04-build-site.yml
+++ b/.github/workflows/04-build-site.yml
@@ -21,6 +21,7 @@ concurrency:
   group: build-and-deploy-${{ github.ref }}
   cancel-in-progress: true
 
+jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
Fix: YAML indentation mistake removed top-level 'jobs' key which caused runs to fail with a workflow parse error. Add 'jobs:' at the correct level.\n\nThis is a tiny YAML fix and should be safe to merge to main.\n\nEvidence: failed run 20896017638 (workflow parse error) and subsequent successful run 20895906604 before the change.