### PR TITLE
fix(ci): use Playwright container for verification job

### DIFF
--- a/.github/workflows/04-build-site.yml
+++ b/.github/workflows/04-build-site.yml
@@ -108,6 +108,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-deploy
     timeout-minutes: 10
+    container:
+      image: mcr.microsoft.com/playwright:v1.49.0-noble
     steps:
       - name: Wait for Pages to be available
         run: |
@@ -127,14 +129,10 @@ jobs:
             exit 1
           fi
 
-      - name: Install Node and Playwright
-        run: |
-          npm init -y
-          npm i -D playwright@1.37.0
-          npx playwright install --with-deps
-
       - name: Screenshot home page (Playwright)
         run: |
+          npm init -y
+          npm i -D playwright@1.49.0
           node -e "const { chromium } = require('playwright'); (async () => { const b = await chromium.launch(); const p = await b.newPage(); await p.goto('https://primeinc.github.io/github-stars/'); await p.screenshot({ path: 'page-verification.png', fullPage: true }); await b.close(); })()"
 
       - name: Upload verification screenshot


### PR DESCRIPTION
Fix: The 'verify-site' job was failing on ubuntu-latest (Ubuntu 24.04) because 'npx playwright install --with-deps' tries to install packages (libasound2, libffi7, libx264-163) that are not available in the 24.04 repos.\n\nSolution: Use the official 'mcr.microsoft.com/playwright:v1.49.0-noble' Docker container for the job. This image comes with browsers and dependencies pre-installed, avoiding the need for apt-get installs.\n\nChanges:\n- Add 'container: mcr.microsoft.com/playwright:v1.49.0-noble' to the verify-site job.\n- Remove 'npx playwright install --with-deps' step.\n- Install playwright npm package inside the container before running the script.\n\nThis should make the verification job robust and independent of runner OS package versions.