### PR TITLE
PR55 follow-up: correct AGENTS.md schema-validator scope; label jitter strategy

### DIFF
--- a/.github/workflows/01-fetch-stars.yml
+++ b/.github/workflows/01-fetch-stars.yml
@@ -83,7 +83,13 @@ jobs:
               error.message?.includes('FetchError')
             );
             
-            // Exponential backoff with full jitter, capped at MAX_BACKOFF_SECONDS.
+            // Exponential backoff with "equal jitter" (sleep range is
+            // [0.5, 1.0) * cappedExp), capped at MAX_BACKOFF_SECONDS. The
+            // 0.5 floor preserves a minimum backoff so tight retry loops
+            // can't hammer api.github.com during a 502 storm; the random
+            // upper half spreads concurrent runs to avoid synchronized
+            // retries (AWS architecture blog, "exponential backoff and
+            // jitter"). Not full jitter (which would be [0, 1) * cappedExp).
             const backoffMs = (attempt) => {
               const expSec = Math.min(MAX_BACKOFF_SECONDS, Math.pow(2, attempt));
               return Math.floor((0.5 + Math.random() * 0.5) * expSec * 1000);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Two layers of validation exist: local TypeScript tests (`vitest`) and Actions-si
 ### Schema Validation
 The primary correctness check is JSON Schema validation for `repos.yml`.
 - **Schema**: `schemas/repos-schema.json`
-- **Validation Tool**: `cardinalby/schema-validator-action` (in CI workflows 02/04) or local `pnpm validate` / `ajv-cli` if installed.
+- **Validation Tool**: `cardinalby/schema-validator-action` (in CI workflows `02-sync-stars` and `03-classify-repos`) or local `pnpm validate` / `ajv-cli` if installed. `04-build-site` does not re-validate `repos.yml`; the strict gates in 02/03 are what protect the build.
 - **Test Command** (Manual):
   ```bash
   pnpm validate


### PR DESCRIPTION
## Summary
Two latent issues on this branch — flagged by Copilot on PR #55 but never propagated into the epic branch:

- **`AGENTS.md` L24** said `cardinalby/schema-validator-action` runs in *"CI workflows 02/04"*. Reality on this branch: it runs in `02-sync-stars.yml` and `03-classify-repos.yml`; `04-build-site.yml` does not re-validate `repos.yml`. Updated the line.
- **`.github/workflows/01-fetch-stars.yml` L86** commented *"Exponential backoff with full jitter"*, but `(0.5 + Math.random() * 0.5) * expSec` returns a value in `[0.5, 1.0) × cappedExp` — that's **equal jitter**, not full jitter. Kept the math (the `0.5` floor is intentional anti-thundering-herd against 502 storms — see commit `f26ced98`), relabeled the comment with a brief justification and a reference to the AWS exponential-backoff-and-jitter post.

## Why this PR rather than fixing PR #55 directly
PR #55's head is `copilot/epic-02-canonical-github-stars-automation` (Copilot-authored). PR #56's head is the epic branch I'm targeting here, and it already supersedes PR #55's content. Fixing on the epic branch resolves the issue at the destination instead of mutating someone else's authored branch.

## Test plan
- [x] `rg cardinalby .github/workflows/` → matches `02-sync-stars.yml` + `03-classify-repos.yml` only
- [ ] Reviewer confirms relabel matches intent (alternative: convert to true full jitter — happy to switch if you prefer the AWS canonical formula `Math.random() * expSec`)
- [ ] No code-path change in `01-fetch-stars` (comment-only)

## Refs
- Closes nothing automatically; addresses unresolved review threads on PR #55:
  - <https://github.com/primeinc/github-stars/pull/55#discussion_r3214218679> (AGENTS.md)
  - <https://github.com/primeinc/github-stars/pull/55#discussion_r3214218694> (jitter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)