### PR TITLE
01-fetch: drop iterator (plugin not bundled), keep plugin-retry

### DIFF
--- a/.github/workflows/01-fetch-stars.yml
+++ b/.github/workflows/01-fetch-stars.yml
@@ -68,18 +68,21 @@ jobs:
           # Default retry-exempt is 400,401,403,404,422; we keep that and add
           # nothing extra. 5xx + 408 + 429 are retried by default.
           script: |
+            // Pagination strategy: hand-rolled while(hasNextPage) loop calling
+            // github.graphql() directly. plugin-retry is loaded by github-script@v8
+            // (refs/actions/github-script/src/main.ts L60: getOctokit(token, opts,
+            // retry, requestLog)) and sits in the request stack, so each
+            // github.graphql() call is automatically retried on real HTTP 5xx
+            // (502/503/504) AND on the GraphQL "Something went wrong while
+            // executing your query" timeout envelope (HTTP 200 with errors[0]
+            // matched in refs/octokit/plugin-retry.js/src/wrap-request.ts L37-62,
+            // which synthesizes a 500 RequestError to feed the bottleneck retry).
+            //
+            // We do NOT use octokit.graphql.paginate.iterator(): the
+            // @octokit/plugin-paginate-graphql plugin is NOT bundled into
+            // github-script@v8 (only retry + requestLog are passed to getOctokit).
             const fs = require('fs');
             const path = require('path');
-            // @octokit/plugin-paginate-graphql is bundled into github-script@v8's
-            // octokit instance via `octokit.graphql.paginate.iterator()`.
-            // First-party plugin source: refs/octokit/plugin-paginate-graphql.js
-            // Requires: cursor variable named $cursor, query has pageInfo
-            // { hasNextPage endCursor }. Both already true for our query.
-            //
-            // Why the iterator and not the merging .paginate(): merging keeps
-            // every edge in memory and prevents per-page incremental writes;
-            // we want to write each page as it arrives so a mid-run failure
-            // still gives us a recoverable cursor for the next dispatch.
 
             const queryPath = 'queries/stars-query.graphql';
             if (!fs.existsSync(queryPath)) {
@@ -145,33 +148,39 @@ jobs:
 
             const allRepos = [];
             let pageCount = 0;
+            let cursor = resumeCursor;
             let lastEndCursor = resumeCursor;
+            let hasNextPage = true;
             let partialFailureReason = '';
 
-            const initialParams = resumeCursor ? { cursor: resumeCursor } : {};
-            const iterator = octokit.graphql.paginate.iterator(STARS_QUERY, initialParams);
+            while (hasNextPage) {
+              pageCount++;
+              core.info(`Fetching page ${pageCount}${cursor ? ` (cursor=${cursor.substring(0, 24)}…)` : ''}...`);
+              let response;
+              try {
+                response = await github.graphql(STARS_QUERY, { cursor });
+              } catch (error) {
+                if (error.message?.includes('Bad credentials')) {
+                  core.setFailed(BAD_CREDENTIALS_MSG);
+                  return;
+                }
+                const errStatus = error.status || 'n/a';
+                const errMsg = (typeof error.message === 'string' ? error.message : String(error)).substring(0, MAX_ERROR_MSG_LENGTH);
+                partialFailureReason =
+                  `graphql_error_at_page_${pageCount}_after_${allRepos.length}_repos_status=${errStatus}_msg=${errMsg}`;
+                core.warning(`GraphQL call failed at page ${pageCount} (after plugin-retry retries exhausted): ${error.message}. ` +
+                  `Cursor for resume: ${lastEndCursor || 'null'}. ` +
+                  `Will write ${allRepos.length} partial results and fail.`);
+                break;
+              }
 
-            try {
-              for await (const response of iterator) {
-                pageCount++;
-                const repos = response.viewer.starredRepositories;
-                const pageRepos = repos.edges.map(transformEdge).filter(r => !r.private);
-                allRepos.push(...pageRepos);
-                lastEndCursor = repos.pageInfo.endCursor;
-                core.info(`  Page ${pageCount}: +${pageRepos.length} public (total: ${allRepos.length}) endCursor=${lastEndCursor?.substring(0, 24) || 'null'}…`);
-              }
-            } catch (error) {
-              if (error.message?.includes('Bad credentials')) {
-                core.setFailed(BAD_CREDENTIALS_MSG);
-                return;
-              }
-              const errStatus = error.status || 'n/a';
-              const errMsg = (typeof error.message === 'string' ? error.message : String(error)).substring(0, MAX_ERROR_MSG_LENGTH);
-              partialFailureReason =
-                `iterator_error_at_page_${pageCount}_after_${allRepos.length}_repos_status=${errStatus}_msg=${errMsg}`;
-              core.warning(`Pagination failed at page ${pageCount}: ${error.message}. ` +
-                `Cursor for resume: ${lastEndCursor || 'null'}. ` +
-                `Will write ${allRepos.length} partial results and fail.`);
+              const repos = response.viewer.starredRepositories;
+              const pageRepos = repos.edges.map(transformEdge).filter(r => !r.private);
+              allRepos.push(...pageRepos);
+              lastEndCursor = repos.pageInfo.endCursor;
+              hasNextPage = repos.pageInfo.hasNextPage;
+              cursor = lastEndCursor;
+              core.info(`  Page ${pageCount}: +${pageRepos.length} public (total: ${allRepos.length}) endCursor=${lastEndCursor?.substring(0, 24) || 'null'}…`);
             }
 
             core.info(`\nTotal: ${allRepos.length} repositories across ${pageCount} pages`);


### PR DESCRIPTION
## What

Fixes the regression I shipped in PR #65. That PR called \`octokit.graphql.paginate.iterator(...)\` assuming the paginate-graphql plugin was bundled into actions/github-script@v8. It is not.

## Direct evidence — verified from local refs after #65 crashed

**Run that crashed (#65 deployed to main):**
- https://github.com/primeinc/github-stars/actions/runs/25622009516
- \`TypeError: Cannot read properties of undefined (reading 'iterator')\`

**Why it crashed (refs/actions/github-script/src/main.ts L60):**
\`\`\`ts
const github = getOctokit(token, opts, retry, requestLog)
\`\`\`
Only \`retry\` and \`requestLog\` are passed as plugins. \`paginateGraphQL\` is not loaded — \`octokit.graphql.paginate\` is undefined.

**What plugin-retry actually does (refs/octokit/plugin-retry.js/src/wrap-request.ts L37-62):**
\`\`\`ts
async function requestWithGraphqlErrorHandling(...) {
  const response = await request(options);
  if (
    response.data && response.data.errors && response.data.errors.length > 0 &&
    /Something went wrong while executing your query/.test(response.data.errors[0].message)
  ) {
    const error = new RequestError(response.data.errors[0].message, 500, { request: options, response });
    return errorRequest(state, octokit, error, options);
  }
  return response;
}
\`\`\`
So with \`retries: 3\` set on the action, every \`github.graphql()\` call is retried automatically on:
- real HTTP 5xx (502/503/504) via the bottleneck \"failed\" hook (L19-29)
- the GraphQL timeout envelope returned as HTTP 200 with \`errors[0].message\` matching \"Something went wrong\" (L37-62)

That covers both failure modes the original 502 storm hit.

## Change

Replaced the \`iterator()\` call with a hand-rolled \`while(hasNextPage)\` loop calling \`github.graphql(STARS_QUERY, { cursor })\` directly. plugin-retry stays active in the request stack because every call goes through \`github.graphql\`.

Kept: \`resume_cursor\` input, hard-fail-on-partial, forensic JSON upload, unchanged GraphQL query.

## Why I'm confident this time

I read wrap-request.ts end-to-end before writing the fix instead of after. The PR #65 description cited \`main.ts L60\` as proof the paginate plugin was bundled — but L60 literally reads \`getOctokit(token, opts, retry, requestLog)\`, which is exactly the line that disproves it. I cited the file that disproved my own claim. That's on me.

## Test plan

- [x] \`pnpm test\` (24 pass)
- [x] \`pnpm validate\` (taxonomy strict on 2,612 repos)
- [x] \`actionlint\` clean
- [ ] CI on this PR
- [ ] After merge: dispatch 01-fetch on main → completes in one shot OR fails with usable resume_cursor

Refs #42, #54, #61. Reverts the broken pagination path from #65 (keeps the \`retries: 3\` and resume_cursor pieces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)