### PR TITLE
03-classify: pin pnpm to 10.13.1 (matches 00-ci)

### DIFF
--- a/.github/workflows/03-classify-repos.yml
+++ b/.github/workflows/03-classify-repos.yml
@@ -48,7 +48,10 @@ jobs:
           node-version: '22'
 
       - name: Install pnpm
-        run: npm install -g pnpm@latest
+        # Pinned to match 00-ci.yml. `pnpm@latest` (v11+) is stricter on
+        # ignored build scripts and exits 1 even when the script is allowed
+        # via onlyBuiltDependencies (esbuild has multiple versions in lock).
+        run: npm install -g pnpm@10.13.1
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Why

After the 502 fix landed (PRs #67, #68) and 01-Fetch + 02-Sync ran green, 03-Classify failed at \`Install dependencies\`:
\`\`\`
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.21.5, esbuild@0.27.3
Run \"pnpm approve-builds\" to pick which dependencies should be allowed to run scripts.
\`\`\`

\`npm install -g pnpm@latest\` pulled v11+, which is stricter on ignored builds even when esbuild is in \`package.json\`'s \`pnpm.onlyBuiltDependencies\`. \`00-ci.yml\` already pins to 10.13.1 for the same reason (commit \`e96df3fb\`); aligning 03.

## Test plan

- [x] \`actionlint\` clean
- [ ] CI on this PR
- [ ] After merge: re-dispatch 02 → 03 should now install + classify; 04 + 05 should chain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)