### PR TITLE
issue #69: TypeScript control plane + GitHub App auth + pnpm gate

### DIFF
--- a/.github/workflows/00-ci.yml
+++ b/.github/workflows/00-ci.yml
@@ -51,6 +51,9 @@ jobs:
           ACTIONLINT_VERSION: '1.7.12'
         run: |
           set -euo pipefail
+          # The downloader requires the target dir to already exist
+          # ("Directory '...' does not exist" error otherwise).
+          mkdir -p "$RUNNER_TEMP/actionlint-bin"
           curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash" \
             | bash -s -- "${ACTIONLINT_VERSION}" "$RUNNER_TEMP/actionlint-bin"
           echo "$RUNNER_TEMP/actionlint-bin" >> "$GITHUB_PATH"

--- a/.github/workflows/00-ci.yml
+++ b/.github/workflows/00-ci.yml
@@ -12,7 +12,10 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  gate:
+    # `pnpm gate` is the single readiness command per issue #69 lesson 1.
+    # Sub-stages: typecheck, test, validate (taxonomy + schema), generated
+    # artifact registry presence, actionlint workflow lint.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -43,68 +46,47 @@ jobs:
           echo "::error::pnpm install failed after 3 attempts"
           exit 1
 
-      - name: Run tests
-        run: pnpm test
+      - name: Install actionlint (used by gate)
+        env:
+          ACTIONLINT_VERSION: '1.7.12'
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash" \
+            | bash -s -- "${ACTIONLINT_VERSION}" "$RUNNER_TEMP/actionlint-bin"
+          echo "$RUNNER_TEMP/actionlint-bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/actionlint-bin/actionlint" -version
 
-      - name: Run repro script
-        run: pnpm repro:taxonomy
-
-      - name: Validate repos.yml (strict)
-        run: pnpm validate
+      - name: pnpm gate
+        run: pnpm gate
 
       - name: CI summary
         if: always()
         run: |
           {
-            echo "# CI (taxonomy + tests)"
+            echo "# CI — pnpm gate"
             echo ""
             echo "- Workflow: \`${{ github.workflow }}\`"
             echo "- Run ID: \`${{ github.run_id }}\`"
             echo "- Trigger: \`${{ github.event_name }}\`"
             echo "- Commit: \`${{ github.sha }}\`"
             echo ""
-            echo "## Gates"
-            echo "- vitest: \`pnpm test\`"
-            echo "- taxonomy repro: \`pnpm repro:taxonomy\`"
-            echo "- strict taxonomy validation: \`pnpm validate\` (NOT JSON Schema; that runs in 02/03)"
+            echo "## Gate stages (\`pnpm gate\`)"
+            echo "- \`typecheck\` (tsc --noEmit)"
+            echo "- \`test\` (vitest)"
+            echo "- \`validate\` (taxonomy + schema)"
+            echo "- generated-artifacts registry presence"
+            echo "- \`actionlint\` workflow lint"
             echo ""
             echo "Web build/lint runs in the separate \`Web CI\` workflow (\`.github/workflows/00b-web-ci.yml\`)."
-            echo "Workflow YAML lint runs in the \`workflow-lint\` job below."
+            echo "Workflow-lint extra footgun guards run in the \`workflow-lint\` job below."
           } >> "$GITHUB_STEP_SUMMARY"
 
   workflow-lint:
-    # Cheap structural and known-footgun checks for .github/workflows/*.yml.
-    # See `.sisyphus/proofs/02M-mode-correction.md` for the bugs this catches.
-    # Issue #62 tracks expanding this to a full nektos/act dry-run if needed.
+    # Cheap structural guards that pnpm gate's actionlint stage cannot
+    # express. See `.sisyphus/proofs/02M-mode-correction.md`.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      # actionlint catches workflow YAML structural issues, expression
-      # errors, missing job dependencies, and a curated set of known-action
-      # input/output mismatches. Pinned to a tag so a bad upstream release
-      # cannot silently change the gate.
-      - name: actionlint
-        env:
-          ACTIONLINT_VERSION: '1.7.12'
-        run: |
-          set -euo pipefail
-          # download-actionlint.bash takes [VERSION] [DIR] positionally; pin
-          # the version explicitly so a future actionlint release cannot
-          # silently change the gate.
-          curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash" \
-            | bash -s -- "${ACTIONLINT_VERSION}" .
-          ./actionlint -version
-          # v1.7.12 errors with "is a directory" if given a bare dir; pass
-          # explicit yaml files so behavior is independent of the version's
-          # default expansion.
-          shopt -s nullglob
-          files=( .github/workflows/*.yml .github/workflows/*.yaml )
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "::error::No workflow files found under .github/workflows/." >&2
-            exit 1
-          fi
-          ./actionlint -color "${files[@]}"
 
       # Specific guard against the cardinalby/schema-validator-action mode
       # footgun. The action accepts default | lax | strong | spec only.
@@ -146,18 +128,16 @@ jobs:
 
       - name: workflow-lint summary
         if: always()
-        env:
-          ACTIONLINT_VERSION: '1.7.12'
         run: |
           {
-            echo "# CI (workflow-lint)"
+            echo "# CI (workflow-lint footgun guards)"
             echo ""
             echo "- Workflow: \`${{ github.workflow }}\`"
             echo "- Run ID: \`${{ github.run_id }}\`"
             echo ""
             echo "## Gates"
-            echo "- \`actionlint v${ACTIONLINT_VERSION}\`"
             echo "- cardinalby/schema-validator-action mode-value guard (rejects unsupported values)"
             echo ""
+            echo "actionlint runs inside \`pnpm gate\` (CI / gate job)."
             echo "Tracking issue for richer dry-run gates: #62"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/01-fetch-stars.yml
+++ b/.github/workflows/01-fetch-stars.yml
@@ -3,8 +3,12 @@ name: '01-Fetch GitHub Stars'
 on:
   workflow_dispatch:
     inputs:
+      auth_mode:
+        description: 'auto | github_app | pat | public | github_token | disabled'
+        required: false
+        default: 'auto'
       resume_cursor:
-        description: 'GraphQL endCursor to resume from (paste from prior failed-run summary). Leave blank to start from page 1.'
+        description: 'GraphQL endCursor to resume from. Leave blank to start from page 1.'
         required: false
         default: ''
   schedule:
@@ -22,354 +26,85 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      total_repos: ${{ steps.fetch-stars.outputs.total_repos }}
-      archived_count: ${{ steps.fetch-stars.outputs.archived_count }}
-      fork_count: ${{ steps.fetch-stars.outputs.fork_count }}
-      no_description_count: ${{ steps.fetch-stars.outputs.no_description_count }}
-      token_source: ${{ steps.token.outputs.source }}
-      output_file: ${{ steps.fetch-stars.outputs.output_file }}
-      output_bytes: ${{ steps.fetch-stars.outputs.output_bytes }}
-      partial_failure_reason: ${{ steps.fetch-stars.outputs.partial_failure_reason }}
-      resume_cursor: ${{ steps.fetch-stars.outputs.resume_cursor }}
-      pages_fetched: ${{ steps.fetch-stars.outputs.pages_fetched }}
+      auth_mode: ${{ steps.doctor.outputs.auth_mode }}
+      star_source_user: ${{ steps.doctor.outputs.star_source_user }}
+      star_fetch_auth: ${{ steps.doctor.outputs.star_fetch_auth }}
+      repo_write_auth: ${{ steps.doctor.outputs.repo_write_auth }}
+      degraded: ${{ steps.doctor.outputs.degraded }}
+      total_repos: ${{ steps.fetch.outputs.total_repos }}
+      archived_count: ${{ steps.fetch.outputs.archived_count }}
+      fork_count: ${{ steps.fetch.outputs.fork_count }}
+      no_description_count: ${{ steps.fetch.outputs.no_description_count }}
+      output_file: ${{ steps.fetch.outputs.output_file }}
+      output_bytes: ${{ steps.fetch.outputs.output_bytes }}
+      partial_failure_reason: ${{ steps.fetch.outputs.partial_failure_reason }}
+      resume_cursor: ${{ steps.fetch.outputs.resume_cursor }}
+      pages_fetched: ${{ steps.fetch.outputs.pages_fetched }}
+      batches_fetched: ${{ steps.fetch.outputs.batches_fetched }}
+      blocked_orgs: ${{ steps.fetch.outputs.blocked_orgs }}
       artifact_name: fetched-stars-${{ github.run_id }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Resolve token source
-        id: token
-        env:
-          STARS_TOKEN_VALUE: ${{ secrets.STARS_TOKEN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        run: npm install -g pnpm@10.13.1
+
+      - name: Install dependencies
         run: |
           set -euo pipefail
-          if [ -n "${STARS_TOKEN_VALUE:-}" ]; then
-            echo "source=STARS_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "Using STARS_TOKEN (PAT)."
-          else
-            echo "source=GITHUB_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "::warning::STARS_TOKEN secret is not set. Falling back to GITHUB_TOKEN, which fetches stars for the workflow's identity (often the wrong account). Set a STARS_TOKEN PAT with read:user scope to make this deterministic. See AGENTS.md §8."
-          fi
+          for attempt in 1 2 3; do
+            if pnpm install --prefer-offline; then exit 0; fi
+            echo "::warning::pnpm install attempt $attempt failed; retrying in 5s..."
+            sleep 5
+          done
+          echo "::error::pnpm install failed after 3 attempts"
+          exit 1
+
+      # Mint a GitHub App installation token when configured. The App
+      # cannot enumerate viewer.starredRepositories (installation tokens
+      # have no user context), so we mint it for repo-write operations
+      # only; star fetch still uses STARS_TOKEN or public mode per the
+      # auth resolver.
+      - name: Mint GitHub App token (when configured)
+        id: app-token
+        if: vars.GH_APP_CLIENT_ID != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Resolve auth mode (setup-doctor)
+        id: doctor
+        env:
+          AUTH_MODE_REQUEST: ${{ inputs.auth_mode || 'auto' }}
+          STAR_SOURCE_USER: ${{ vars.STAR_SOURCE_USER || 'primeinc' }}
+          GH_APP_CLIENT_ID: ${{ vars.GH_APP_CLIENT_ID }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          STARS_TOKEN: ${{ secrets.STARS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm auth:doctor
 
       - name: Fetch starred repositories
-        uses: actions/github-script@v8
-        id: fetch-stars
-        with:
-          github-token: ${{ secrets.STARS_TOKEN || secrets.GITHUB_TOKEN }}
-          # Enable @octokit/plugin-retry (refs/actions/github-script/src/main.ts
-          # L60: getOctokit(token, opts, retry, requestLog)). Default is "0"
-          # (disabled). 5 retries cover real 5xx (502/503/504) + the GraphQL
-          # "Something went wrong" timeout envelope (refs/octokit/
-          # plugin-retry.js/src/wrap-request.ts L37-62). Honors Retry-After.
-          retries: 5
-          # Default retry-exempt is 400,401,403,404,422; we keep that and add
-          # nothing extra. 5xx + 408 + 429 are retried by default.
-          script: |
-            // Two-stage fetch per GitHub's own published guidance for heavy
-            // queries: refs/github/docs/content/graphql/overview/
-            // rate-limits-and-query-limits-for-the-graphql-api.md L286-294
-            // (10s server-side timeout) + L308-316 ("Split large queries",
-            // "Request only required fields") + the pagination guide L49
-            // ("request fewer than 100 items if your query touches a lot of
-            // data"). Local repro confirmed the prior single-query approach
-            // (first:100 with latestRelease + licenseInfo + repositoryTopics
-            // + defaultBranchRef.target.oid) takes 20s/page and 502s on
-            // page 2 under load. Cheap-only paginates 2,623 stars in 47s
-            // (every page <3.5s); 25-repo aliased metadata batch returns in
-            // ~3.4s. Total ~7min worst case, well under timeout-minutes: 30.
-            //
-            // plugin-retry IS active (github-script@v8 main.ts L60 passes it
-            // to getOctokit) and handles 5xx + GraphQL "Something went wrong"
-            // envelope per refs/octokit/plugin-retry.js/src/wrap-request.ts
-            // L37-62. retries: 5 below.
-            const fs = require('fs');
-            const path = require('path');
-
-            const LIST_QUERY_PATH = 'queries/stars-list-query.graphql';
-            const FRAGMENT_PATH = 'queries/stars-metadata-fragment.graphql';
-            for (const p of [LIST_QUERY_PATH, FRAGMENT_PATH]) {
-              if (!fs.existsSync(p)) throw new Error(`Required query file not found: ${p}`);
-            }
-            const LIST_QUERY = fs.readFileSync(LIST_QUERY_PATH, 'utf8');
-            const METADATA_FRAGMENT = fs.readFileSync(FRAGMENT_PATH, 'utf8');
-
-            const OUTPUT_FILE = '.github-stars/data/fetched-stars-graphql.json';
-            const MAX_ERROR_MSG_LENGTH = 200;
-            const METADATA_BATCH_SIZE = 25;
-
-            // Resume support. workflow_dispatch input wins; otherwise start fresh.
-            const resumeCursor = (process.env.RESUME_CURSOR || '').trim() || null;
-            if (resumeCursor) {
-              core.info(`Resuming pagination from cursor: ${resumeCursor.substring(0, 40)}…`);
-            }
-
-            const BAD_CREDENTIALS_MSG =
-              'Authentication failed: Bad credentials. ' +
-              'The STARS_TOKEN secret is expired or invalid. ' +
-              'Please generate a new Personal Access Token with "read:user" scope ' +
-              'and update the STARS_TOKEN repository secret.';
-
-            try {
-              await github.graphql('{ viewer { login } }');
-            } catch (authError) {
-              if (authError.message?.includes('Bad credentials')) {
-                core.setFailed(BAD_CREDENTIALS_MSG);
-                return;
-              }
-              throw authError;
-            }
-
-            // ──────── Stage 1: cheap pagination ────────
-            // Returns minimal fields per page. Each page <3.5s in local repro.
-            const starredList = [];
-            let pageCount = 0;
-            let cursor = resumeCursor;
-            let lastEndCursor = resumeCursor;
-            let hasNextPage = true;
-            let partialFailureReason = '';
-
-            // Org-blocked-PAT collector: orgs that return
-            // "forbids access via a personal access token (classic)"
-            // mean classic-PAT tokens can't see repos in those orgs. The
-            // GraphQL endpoint returns the partial-data shape per
-            // refs/octokit/.../@octokit/graphql/dist-src/graphql.js L49-62
-            // (response.data.errors triggers GraphqlResponseError, but the
-            // error object retains .data so downstream still gets what
-            // succeeded — error.js L11-12 sets this.data = response.data).
-            const inaccessibleOrgs = new Set();
-            const otherErrors = [];
-
-            const extractPartialList = (graphqlError) => {
-              // Returns viewer.starredRepositories from the partial response
-              // when GraphqlResponseError carries data; null otherwise.
-              return graphqlError?.data?.viewer?.starredRepositories || null;
-            };
-
-            core.info('Stage 1: paginating star list (cheap query)...');
-            while (hasNextPage) {
-              pageCount++;
-              let repos = null;
-              try {
-                const response = await github.graphql(LIST_QUERY, { cursor });
-                repos = response.viewer.starredRepositories;
-              } catch (error) {
-                if (error.message?.includes('Bad credentials')) {
-                  core.setFailed(BAD_CREDENTIALS_MSG);
-                  return;
-                }
-                // Octokit throws GraphqlResponseError when response.data.errors
-                // is present, but preserves response.data on the error object
-                // (see refs/octokit/.../@octokit/graphql/dist-src/error.js L11).
-                // For org-blocked-PAT errors specifically, GitHub returns the
-                // pageful that succeeded plus an error per blocked repo.
-                const partialList = extractPartialList(error);
-                if (partialList) {
-                  repos = partialList;
-                  for (const e of error.errors || []) {
-                    const m = (e.message || '').match(/^`([^`]+)` forbids access via a personal access token \(classic\)/);
-                    if (m) {
-                      inaccessibleOrgs.add(m[1]);
-                    } else {
-                      otherErrors.push((e.message || '').substring(0, MAX_ERROR_MSG_LENGTH));
-                    }
-                  }
-                  core.warning(`page ${pageCount}: partial response (${error.errors?.length || 0} graphql errors, continuing). Sample: ${(error.errors?.[0]?.message || '').substring(0, 120)}`);
-                } else {
-                  const errStatus = error.status || 'n/a';
-                  const errMsg = (typeof error.message === 'string' ? error.message : String(error)).substring(0, MAX_ERROR_MSG_LENGTH);
-                  partialFailureReason =
-                    `list_error_at_page_${pageCount}_after_${starredList.length}_repos_status=${errStatus}_msg=${errMsg}`;
-                  core.warning(`Stage 1 list query failed at page ${pageCount}: ${error.message}. ` +
-                    `Cursor for resume: ${lastEndCursor || 'null'}.`);
-                  break;
-                }
-              }
-              if (!repos) break;
-              for (const edge of repos.edges) {
-                if (edge?.node && !edge.node.isPrivate) {
-                  starredList.push({ repo: edge.node.nameWithOwner, user_starred_at: edge.starredAt });
-                }
-              }
-              lastEndCursor = repos.pageInfo.endCursor;
-              hasNextPage = repos.pageInfo.hasNextPage;
-              cursor = lastEndCursor;
-              if (pageCount % 5 === 0) {
-                core.info(`  list page ${pageCount}: total=${starredList.length}/${repos.totalCount}`);
-              }
-            }
-
-            if (inaccessibleOrgs.size > 0) {
-              core.warning(`Skipped ${inaccessibleOrgs.size} orgs that block classic-PAT access: ${[...inaccessibleOrgs].sort().join(', ')}. To include them, regenerate STARS_TOKEN as a fine-grained PAT with read access.`);
-            }
-            if (otherErrors.length > 0) {
-              core.warning(`Stage 1 collected ${otherErrors.length} non-org-blocked GraphQL errors. First 3: ${otherErrors.slice(0, 3).join(' | ')}`);
-            }
-
-            if (partialFailureReason) {
-              // Stage 1 failed; write what we have and bail.
-              fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
-              fs.writeFileSync(OUTPUT_FILE, JSON.stringify([], null, 2));
-              core.setOutput('total_repos', 0);
-              core.setOutput('archived_count', 0);
-              core.setOutput('fork_count', 0);
-              core.setOutput('no_description_count', 0);
-              core.setOutput('output_file', OUTPUT_FILE);
-              core.setOutput('output_bytes', fs.statSync(OUTPUT_FILE).size);
-              core.setOutput('partial_failure_reason', partialFailureReason);
-              core.setOutput('pages_fetched', pageCount);
-              core.setOutput('resume_cursor', lastEndCursor || '');
-              core.setFailed(`Star fetch incomplete (stage 1): ${partialFailureReason}. ` +
-                `To resume, dispatch this workflow with input resume_cursor='${lastEndCursor || ''}'.`);
-              return;
-            }
-
-            core.info(`Stage 1 done: ${starredList.length} public stars across ${pageCount} pages.`);
-
-            // ──────── Stage 2: aliased per-repo metadata batches ────────
-            // 25 repos per query. Each batch ~3.4s in local repro.
-            core.info(`Stage 2: fetching metadata in batches of ${METADATA_BATCH_SIZE}...`);
-            const starredAtByRepo = new Map(starredList.map(s => [s.repo, s.user_starred_at]));
-            const allRepos = [];
-            let batchCount = 0;
-            let stage2Failure = '';
-
-            const buildBatchQuery = (batch) => {
-              const varDecls = batch.map((_, i) => `$o${i}: String!, $n${i}: String!`).join(', ');
-              const aliases = batch.map((_, i) =>
-                `r${i}: repository(owner: $o${i}, name: $n${i}) { ...RepoMetadata }`
-              ).join('\n  ');
-              return `${METADATA_FRAGMENT}\nquery(${varDecls}) {\n  ${aliases}\n}`;
-            };
-
-            const transformNode = (repoFullName, node) => {
-              const [owner, name] = repoFullName.split('/');
-              return {
-                repo: repoFullName,
-                description: node.description || '',
-                language: node.primaryLanguage?.name || null,
-                topics: node.repositoryTopics.nodes.map(n => n.topic.name),
-                archived: node.isArchived,
-                fork: node.isFork,
-                private: node.isPrivate,
-                stargazers_count: node.stargazerCount,
-                forks_count: node.forkCount,
-                updated_at: node.updatedAt,
-                pushed_at: node.pushedAt,
-                disk_usage: node.diskUsage,
-                owner_avatar: node.owner.avatarUrl,
-                html_url: node.url,
-                default_branch: node.defaultBranchRef?.name || 'main',
-                last_commit_sha: node.defaultBranchRef?.target?.oid || null,
-                user_starred_at: starredAtByRepo.get(repoFullName) || null,
-                homepage_url: node.homepageUrl,
-                is_mirror: node.isMirror,
-                mirror_url: node.mirrorUrl,
-                license: node.licenseInfo?.spdxId || null,
-                latest_release: node.latestRelease ? {
-                  tag: node.latestRelease.tagName,
-                  published_at: node.latestRelease.publishedAt
-                } : null
-              };
-            };
-
-            for (let i = 0; i < starredList.length; i += METADATA_BATCH_SIZE) {
-              const batch = starredList.slice(i, i + METADATA_BATCH_SIZE).map(s => {
-                const [owner, name] = s.repo.split('/');
-                return [owner, name, s.repo];
-              });
-              batchCount++;
-              const query = buildBatchQuery(batch);
-              const vars = {};
-              batch.forEach((b, j) => { vars[`o${j}`] = b[0]; vars[`n${j}`] = b[1]; });
-              let resp = null;
-              try {
-                resp = await github.graphql(query, vars);
-              } catch (error) {
-                // Same partial-data handling as stage 1: GraphqlResponseError
-                // preserves response.data on the error object. Aliases that
-                // succeeded are present; failed ones are null.
-                if (error.data && typeof error.data === 'object') {
-                  resp = error.data;
-                  for (const e of error.errors || []) {
-                    const m = (e.message || '').match(/^`([^`]+)` forbids access via a personal access token \(classic\)/);
-                    if (m) inaccessibleOrgs.add(m[1]);
-                  }
-                } else {
-                  const errStatus = error.status || 'n/a';
-                  const errMsg = (typeof error.message === 'string' ? error.message : String(error)).substring(0, MAX_ERROR_MSG_LENGTH);
-                  stage2Failure = `metadata_batch_${batchCount}_failed_after_${allRepos.length}_repos_status=${errStatus}_msg=${errMsg}`;
-                  core.warning(`Stage 2 batch ${batchCount} failed (after plugin-retry exhausted): ${error.message}. ` +
-                    `Will write ${allRepos.length} partial results and fail.`);
-                  break;
-                }
-              }
-              if (resp) {
-                for (let j = 0; j < batch.length; j++) {
-                  const node = resp[`r${j}`];
-                  if (node) allRepos.push(transformNode(batch[j][2], node));
-                }
-                if (batchCount % 10 === 0) {
-                  core.info(`  batch ${batchCount}: ${allRepos.length}/${starredList.length} fetched`);
-                }
-              }
-            }
-
-            // A gap of (starredList.length - allRepos.length) is fine when
-            // it matches the count of org-blocked-PAT skips (we already
-            // logged those orgs). Treat as failure only if the gap exceeds
-            // a small tolerance OR no inaccessibleOrgs explain it.
-            const gap = starredList.length - allRepos.length;
-            if (!stage2Failure && gap > 0) {
-              if (inaccessibleOrgs.size > 0 && gap < starredList.length * 0.10) {
-                core.info(`Stage 2 expected gap: ${gap} repos in classic-PAT-blocked orgs (${inaccessibleOrgs.size} orgs).`);
-              } else {
-                stage2Failure = `metadata_incomplete_${allRepos.length}_of_${starredList.length}_gap=${gap}`;
-                core.warning(`Stage 2 left ${gap} repos unfetched, more than the ${inaccessibleOrgs.size} blocked orgs explain.`);
-              }
-            }
-            partialFailureReason = stage2Failure || partialFailureReason;
-
-            core.info(`\nTotal: ${allRepos.length} repositories — list pages=${pageCount} metadata batches=${batchCount}`);
-
-            const outputDir = path.dirname(OUTPUT_FILE);
-            if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
-            fs.writeFileSync(OUTPUT_FILE, JSON.stringify(allRepos, null, 2));
-            const outputBytes = fs.statSync(OUTPUT_FILE).size;
-
-            const archived = allRepos.filter(r => r.archived).length;
-            const forks = allRepos.filter(r => r.fork).length;
-            const noDesc = allRepos.filter(r => !r.description).length;
-
-            core.info(`Archived: ${archived}, Forks: ${forks}, No description: ${noDesc}`);
-
-            core.setOutput('total_repos', allRepos.length);
-            core.setOutput('archived_count', archived);
-            core.setOutput('fork_count', forks);
-            core.setOutput('no_description_count', noDesc);
-            core.setOutput('output_file', OUTPUT_FILE);
-            core.setOutput('output_bytes', outputBytes);
-            core.setOutput('partial_failure_reason', partialFailureReason);
-            core.setOutput('pages_fetched', pageCount);
-            // Always emit the LAST seen cursor so a partial run can be resumed
-            // by a workflow_dispatch with this string pasted into resume_cursor.
-            // Empty when fetch never advanced past the initial state.
-            core.setOutput('resume_cursor', lastEndCursor || '');
-
-            if (partialFailureReason) {
-              core.setFailed(
-                `Star fetch incomplete: ${partialFailureReason}. ` +
-                `Wrote ${allRepos.length} partial repos to ${OUTPUT_FILE} (${outputBytes} bytes) for forensic analysis. ` +
-                `To resume, dispatch this workflow with input resume_cursor='${lastEndCursor || ''}'. ` +
-                `Refusing to declare success on a partial fetch — downstream sync would reconcile against a sliver of the real star set.`
-              );
-            }
+        id: fetch
         env:
+          # Star-fetch token: PAT preferred (App can't paginate user.starred);
+          # falls back to GITHUB_TOKEN identity (degraded — fetches the bot's stars).
+          GH_TOKEN: ${{ secrets.STARS_TOKEN || secrets.GITHUB_TOKEN }}
           RESUME_CURSOR: ${{ inputs.resume_cursor }}
+        run: pnpm fetch:stars
 
       - name: Upload results
         # Upload on success and on partial-failure so the forensic JSON is preserved.
-        if: always() && steps.fetch-stars.outputs.output_bytes != ''
+        if: always() && steps.fetch.outputs.output_bytes != ''
         id: upload
         uses: actions/upload-artifact@v6
         with:
@@ -382,6 +117,10 @@ jobs:
         # Only commit on a clean fetch. Partial-failure JSON is artifact-only.
         if: success()
         id: commit
+        env:
+          # Prefer GitHub App token for commits; fall back to STARS_TOKEN/GITHUB_TOKEN
+          # so existing setups continue to work while the App is being installed.
+          GIT_TOKEN: ${{ steps.app-token.outputs.token || secrets.STARS_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -402,9 +141,11 @@ jobs:
           fi
 
           git commit -m "chore: update starred repositories [skip ci]"
+          # Use the resolved token for push so we can use the GitHub App token when present.
+          remote_url="https://x-access-token:${GIT_TOKEN}@github.com/${{ github.repository }}.git"
           pushed=false
           for attempt in 1 2 3 4 5; do
-            if git pull --rebase --autostash origin main && git push; then
+            if git pull --rebase --autostash "$remote_url" main && git push "$remote_url" HEAD:main; then
               pushed=true
               break
             fi
@@ -412,7 +153,7 @@ jobs:
             sleep 10
           done
           if [ "$pushed" != "true" ]; then
-            echo "::error::Failed to push fetched-stars JSON after 5 attempts. The artifact (fetched-stars-${{ github.run_id }}) is still available for the downstream sync step."
+            echo "::error::Failed to push fetched-stars JSON after 5 attempts. The artifact is still available for the downstream sync step."
             echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -422,16 +163,22 @@ jobs:
       - name: Fetch summary
         if: always()
         env:
-          TOKEN_SOURCE: ${{ steps.token.outputs.source }}
-          TOTAL: ${{ steps.fetch-stars.outputs.total_repos }}
-          ARCHIVED: ${{ steps.fetch-stars.outputs.archived_count }}
-          FORKS: ${{ steps.fetch-stars.outputs.fork_count }}
-          NO_DESC: ${{ steps.fetch-stars.outputs.no_description_count }}
-          OUTPUT_FILE: ${{ steps.fetch-stars.outputs.output_file }}
-          OUTPUT_BYTES: ${{ steps.fetch-stars.outputs.output_bytes }}
-          PARTIAL_REASON: ${{ steps.fetch-stars.outputs.partial_failure_reason }}
-          PAGES_FETCHED: ${{ steps.fetch-stars.outputs.pages_fetched }}
-          RESUME_CURSOR: ${{ steps.fetch-stars.outputs.resume_cursor }}
+          AUTH_MODE: ${{ steps.doctor.outputs.auth_mode }}
+          STAR_SOURCE_USER: ${{ steps.doctor.outputs.star_source_user }}
+          STAR_FETCH_AUTH: ${{ steps.doctor.outputs.star_fetch_auth }}
+          REPO_WRITE_AUTH: ${{ steps.doctor.outputs.repo_write_auth }}
+          DEGRADED: ${{ steps.doctor.outputs.degraded }}
+          TOTAL: ${{ steps.fetch.outputs.total_repos }}
+          ARCHIVED: ${{ steps.fetch.outputs.archived_count }}
+          FORKS: ${{ steps.fetch.outputs.fork_count }}
+          NO_DESC: ${{ steps.fetch.outputs.no_description_count }}
+          OUTPUT_FILE: ${{ steps.fetch.outputs.output_file }}
+          OUTPUT_BYTES: ${{ steps.fetch.outputs.output_bytes }}
+          PARTIAL_REASON: ${{ steps.fetch.outputs.partial_failure_reason }}
+          PAGES_FETCHED: ${{ steps.fetch.outputs.pages_fetched }}
+          BATCHES_FETCHED: ${{ steps.fetch.outputs.batches_fetched }}
+          RESUME_CURSOR: ${{ steps.fetch.outputs.resume_cursor }}
+          BLOCKED_ORGS: ${{ steps.fetch.outputs.blocked_orgs }}
           INPUT_RESUME_CURSOR: ${{ inputs.resume_cursor }}
           ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
@@ -446,16 +193,24 @@ jobs:
             echo "- Run ID: \`${{ github.run_id }}\`"
             echo "- Trigger: \`${{ github.event_name }}\`"
             echo "- Commit: \`${{ github.sha }}\`"
-            echo "- Token source: \`${TOKEN_SOURCE:-unresolved}\`"
+            echo ""
+            echo "## Auth"
+            echo "- auth_mode: \`${AUTH_MODE:-unresolved}\`${DEGRADED:+ (degraded=$DEGRADED)}"
+            echo "- star_source_user: \`${STAR_SOURCE_USER:-unset}\`"
+            echo "- star_fetch_auth: \`${STAR_FETCH_AUTH:-?}\`"
+            echo "- repo_write_auth: \`${REPO_WRITE_AUTH:-?}\`"
             if [ -n "${INPUT_RESUME_CURSOR:-}" ]; then
               echo "- Resumed from cursor: \`${INPUT_RESUME_CURSOR:0:24}…\`"
             fi
             echo ""
             echo "## Counts"
-            echo "- Total repos: \`${TOTAL:-?}\` across \`${PAGES_FETCHED:-?}\` pages"
+            echo "- Total repos: \`${TOTAL:-?}\` across \`${PAGES_FETCHED:-?}\` list pages and \`${BATCHES_FETCHED:-?}\` metadata batches"
             echo "- Archived: \`${ARCHIVED:-?}\`"
             echo "- Forks: \`${FORKS:-?}\`"
             echo "- No description: \`${NO_DESC:-?}\`"
+            if [ -n "${BLOCKED_ORGS:-}" ]; then
+              echo "- Skipped orgs (classic-PAT blocked): \`${BLOCKED_ORGS}\`"
+            fi
             echo ""
             echo "## Outputs"
             echo "- File: \`${OUTPUT_FILE:-n/a}\` (${OUTPUT_BYTES:-0} bytes)"
@@ -473,7 +228,7 @@ jobs:
               if [ -n "${RESUME_CURSOR:-}" ]; then
                 echo "### Resume from where this run stopped"
                 echo ""
-                echo "Re-dispatch this workflow with the following input to continue from page $((${PAGES_FETCHED:-0} + 1)):"
+                echo "Re-dispatch this workflow with the following input to continue:"
                 echo ""
                 echo "\`\`\`"
                 echo "resume_cursor: ${RESUME_CURSOR}"

--- a/.github/workflows/02-sync-stars.yml
+++ b/.github/workflows/02-sync-stars.yml
@@ -3,6 +3,11 @@ name: '02-Sync Starred Repos'
 
 on:
   workflow_dispatch:
+    inputs:
+      removal_override:
+        description: 'Set true to bypass the 5% destructive-deletion guard'
+        required: false
+        default: 'false'
   workflow_run:
     workflows: ["01-Fetch GitHub Stars"]
     types:
@@ -24,10 +29,6 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    # Only sync on success from a main-branch fetch run; for
-    # workflow_dispatch only allow triggering from main. Both rules
-    # protect against cross-branch writes since this job hardcodes
-    # `ref: main` for checkout and push.
     if: |
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
       || (github.event_name == 'workflow_run'
@@ -41,28 +42,45 @@ jobs:
           fetch-depth: 0
           ref: main
 
-      - name: Check if repos.yml exists
-        id: check_repos
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        run: npm install -g pnpm@10.13.1
+
+      - name: Install dependencies
         run: |
           set -euo pipefail
-          if [ -f "repos.yml" ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          for attempt in 1 2 3; do
+            if pnpm install --prefer-offline; then exit 0; fi
+            echo "::warning::pnpm install attempt $attempt failed; retrying in 5s..."
+            sleep 5
+          done
+          echo "::error::pnpm install failed after 3 attempts"
+          exit 1
+
+      # Mint a GitHub App installation token when configured. Used for
+      # the commit/push at the end so we can stop relying on
+      # github-actions[bot] identity.
+      - name: Mint GitHub App token (when configured)
+        id: app-token
+        if: vars.GH_APP_CLIENT_ID != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Validate existing manifest (schema gate)
         # cardinalby/schema-validator-action@v3 mode values are
         # `default | lax | strong | spec` (per action.yml; uses schemasafe
-        # under the hood). There is NO `strict`; passing it errors at
-        # action input validation time with `"mode" has unknown value
-        # "strict"`. `default` is what we want here: it enforces the
+        # under the hood). There is NO `strict`. `default` enforces the
         # schema's `additionalProperties: false`, required fields, types,
-        # enums, and patterns. `strong` would also require coherence
-        # checks like `maxLength` next to every `pattern`, which our
-        # schema does not satisfy (verified locally with @exodus/schemasafe).
-        # See `.sisyphus/proofs/02M-mode-correction.md`.
-        if: steps.check_repos.outputs.exists == 'true'
+        # enums, and patterns. See `.sisyphus/proofs/02M-mode-correction.md`.
+        if: hashFiles('repos.yml') != ''
         uses: cardinalby/schema-validator-action@v3
         with:
           schema: 'schemas/repos-schema.json'
@@ -110,14 +128,12 @@ jobs:
         run: |
           set -euo pipefail
           # In workflow_run mode the artifact is the canonical handoff. If
-          # the download did not succeed (missing artifact, expired
-          # retention, permission failure), fail hard instead of silently
-          # reconciling against potentially-stale committed data. The
-          # committed JSON is only allowed for workflow_dispatch.
+          # the download did not succeed, fail hard instead of silently
+          # reconciling against potentially-stale committed data.
           if [ "$MODE" = "artifact" ] && [ "$DOWNLOAD_OUTCOME" != "success" ]; then
             {
               echo "::error::Artifact download failed for triggering run $TRIGGER_RUN_ID (artifact=$ARTIFACT_NAME, outcome=$DOWNLOAD_OUTCOME)."
-              echo "::error::Refusing to fall back to the committed fetched-stars JSON in workflow_run mode; that data may be stale relative to the run that triggered this sync."
+              echo "::error::Refusing to fall back to the committed fetched-stars JSON in workflow_run mode."
               echo "::error::Investigate the triggering 01-Fetch GitHub Stars run, then rerun this workflow via workflow_dispatch if you intend to use the committed JSON."
             } >&2
             exit 1
@@ -142,192 +158,14 @@ jobs:
           echo "input_bytes=$bytes" >> "$GITHUB_OUTPUT"
           echo "Resolved fetched-stars source: $src ($bytes bytes)"
 
-      - name: Update manifest
+      - name: Sync manifest
         id: diff
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            const { execSync } = require('child_process');
-
-            const starsDataPath = '.github-stars/data/fetched-stars-graphql.json';
-            if (!fs.existsSync(starsDataPath)) {
-              core.setFailed(`Missing input: ${starsDataPath}. Verify artifact handoff or run fetch-stars first.`);
-              return;
-            }
-
-            const starsData = JSON.parse(fs.readFileSync(starsDataPath, 'utf8'));
-            if (!Array.isArray(starsData)) {
-              core.setFailed('Invalid stars data format: expected array');
-              return;
-            }
-
-            console.log(`Found ${starsData.length} starred repositories`);
-
-            let yamlContent;
-            if (fs.existsSync('repos.yml')) {
-              yamlContent = fs.readFileSync('repos.yml', 'utf8');
-            } else {
-              yamlContent = fs.readFileSync('.github-stars/repos-template.yml', 'utf8');
-            }
-
-            // mikefarah/yq is preinstalled on ubuntu-latest runners.
-            const manifestJson = execSync('yq eval -o=json -', {
-              input: yamlContent,
-              encoding: 'utf8',
-              maxBuffer: 50 * 1024 * 1024
-            });
-            const manifestData = JSON.parse(manifestJson) || { repositories: [] };
-
-            if (!manifestData.repositories) manifestData.repositories = [];
-            if (!manifestData.manifest_metadata) manifestData.manifest_metadata = {};
-            manifestData.manifest_metadata.github_user = context.repo.owner;
-
-            const existingRepos = new Set(manifestData.repositories.filter(r => r?.repo).map(r => r.repo));
-            const newRepos = starsData.filter(s => s?.repo && !existingRepos.has(s.repo));
-            const currentStarRepos = new Set(starsData.filter(s => s?.repo).map(s => s.repo));
-            const removedRepos = manifestData.repositories.filter(r => r?.repo && !currentStarRepos.has(r.repo));
-
-            console.log(`New: ${newRepos.length}, Removed: ${removedRepos.length}`);
-
-            // DESTRUCTIVE-DELETION GUARD
-            // Refuse to apply a sync that would remove more than 5% of the
-            // current manifest. Direct evidence motivating this guard:
-            // .sisyphus/proofs/02N-recovery.md documents how silent partial
-            // fetches truncated repos.yml from 2,612 → 197 (lost ~92% of
-            // entries) by repeatedly running this exact diff against fetched
-            // pages 1+2 only. The 01-fetch hard-fail (post-ee50e48c) prevents
-            // future poisoning at the source, but this guard is defense in
-            // depth: any fetched-stars JSON that produces a > 5% removal
-            // ratio is, by definition, suspicious.
-            //
-            // Threshold: 5%. Bypass is intentional to require a human
-            // (or workflow_dispatch with explicit input) to confirm a
-            // genuinely large unstar event.
-            const manifestSize = manifestData.repositories.length;
-            const removalRatio = manifestSize > 0 ? removedRepos.length / manifestSize : 0;
-            const REMOVAL_THRESHOLD = 0.05;
-            if (removalRatio > REMOVAL_THRESHOLD) {
-              const removedNames = removedRepos.slice(0, 20).map(r => r.repo).join(', ');
-              core.setFailed(
-                `DESTRUCTIVE SYNC REFUSED: fetched ${starsData.length} stars but ` +
-                `manifest has ${manifestSize}; that would remove ${removedRepos.length} repos ` +
-                `(${(removalRatio * 100).toFixed(1)}% — exceeds ${(REMOVAL_THRESHOLD * 100).toFixed(0)}% threshold). ` +
-                `First 20 to-be-removed: ${removedNames}${removedRepos.length > 20 ? ', ...' : ''}. ` +
-                `If this is intentional (mass unstar), set MANIFEST_REMOVAL_OVERRIDE=true in workflow env. ` +
-                `Otherwise the upstream fetch is suspect — check 01-Fetch GitHub Stars run for partial-success warnings.`
-              );
-              return;
-            }
-
-            if (newRepos.length > 0 || removedRepos.length > 0) {
-              manifestData.repositories = manifestData.repositories.filter(r => r?.repo && currentStarRepos.has(r.repo));
-
-              const cleanDescription = (desc) => {
-                if (!desc?.trim()) return 'No description provided';
-                let cleaned = desc
-                  .replace(/^#+\s*/, '')
-                  .replace(/([a-z])([A-Z])/g, '$1 $2')
-                  .replace(/\s+/g, ' ')
-                  .trim();
-                return cleaned.length > 200 ? cleaned.substring(0, 197) + '...' : cleaned;
-              };
-
-              const newEntries = newRepos.map(repo => ({
-                repo: repo.repo,
-                categories: ["unclassified"],
-                tags: [],
-                summary: cleanDescription(repo.description),
-                last_synced_sha: repo.last_commit_sha || '0'.repeat(40),
-                user_starred_at: repo.user_starred_at || new Date().toISOString(),
-                readme_quality: "missing",
-                needs_review: true,
-                ...(repo.archived && { archived: true }),
-                ...(repo.fork && { fork: true }),
-                github_metadata: {
-                  language: repo.language || null,
-                  topics: repo.topics || [],
-                  stargazers_count: repo.stargazers_count || 0,
-                  forks_count: repo.forks_count || 0,
-                  disk_usage: repo.disk_usage || null,
-                  owner_avatar: repo.owner_avatar || null,
-                  homepage_url: repo.homepage_url || null,
-                  license: repo.license || null,
-                  repo_pushed_at: repo.pushed_at || null,
-                  repo_updated_at: repo.updated_at || null,
-                  html_url: repo.html_url || null,
-                  default_branch: repo.default_branch || null,
-                  latest_release: repo.latest_release || null,
-                  is_mirror: repo.is_mirror || false,
-                  mirror_url: repo.mirror_url || null
-                }
-              }));
-
-              manifestData.repositories.push(...newEntries);
-              manifestData.manifest_metadata.manifest_updated_at = new Date().toISOString();
-              manifestData.manifest_metadata.total_repos = manifestData.repositories.length;
-
-              fs.writeFileSync('.github-stars/data/manifest.json', JSON.stringify(manifestData, null, 2));
-            }
-
-            // Sync metadata for existing repos
-            let updatedCount = 0;
-            const repoMap = new Map(starsData.map(s => [s.repo, s]));
-            for (const repo of manifestData.repositories) {
-              const fresh = repoMap.get(repo.repo);
-              if (!fresh) continue;
-
-              let changed = false;
-
-              if (fresh.user_starred_at && fresh.user_starred_at !== repo.user_starred_at) {
-                repo.user_starred_at = fresh.user_starred_at;
-                changed = true;
-              }
-
-              if (repo.last_synced_sha !== fresh.last_commit_sha && fresh.last_commit_sha) {
-                repo.last_synced_sha = fresh.last_commit_sha;
-                changed = true;
-              }
-
-              if (fresh.updated_at && (!repo.github_metadata || repo.github_metadata.repo_updated_at !== fresh.updated_at)) {
-                if (!repo.github_metadata) repo.github_metadata = {};
-                repo.github_metadata.repo_updated_at = fresh.updated_at;
-                repo.github_metadata.repo_pushed_at = fresh.pushed_at;
-                repo.github_metadata.stargazers_count = fresh.stargazers_count;
-                repo.github_metadata.forks_count = fresh.forks_count;
-                repo.github_metadata.disk_usage = fresh.disk_usage;
-                repo.github_metadata.owner_avatar = fresh.owner_avatar;
-                repo.github_metadata.language = fresh.language;
-                repo.github_metadata.topics = fresh.topics;
-                repo.github_metadata.license = fresh.license;
-                changed = true;
-              }
-
-              if (changed) updatedCount++;
-            }
-
-            const changed = newRepos.length > 0 || removedRepos.length > 0 || updatedCount > 0;
-            if (changed) {
-              console.log(`Updated metadata for ${updatedCount} existing repositories`);
-              fs.writeFileSync('.github-stars/data/manifest.json', JSON.stringify(manifestData, null, 2));
-            }
-
-            core.setOutput('changed', changed ? 'true' : 'false');
-            core.setOutput('total_new', newRepos.length);
-            core.setOutput('total_removed', removedRepos.length);
-            core.setOutput('total_updated', updatedCount);
-            core.setOutput('total_repos', manifestData.repositories.length);
-
-      - name: Convert to YAML
-        if: steps.diff.outputs.changed == 'true'
-        run: yq eval '.' .github-stars/data/manifest.json -o=yaml > repos.yml
-
-      - name: Cleanup intermediate JSON
-        if: always()
-        run: rm -f .github-stars/data/manifest.json
+        env:
+          GITHUB_USER: ${{ github.repository_owner }}
+          MANIFEST_REMOVAL_OVERRIDE: ${{ inputs.removal_override }}
+        run: pnpm sync:stars
 
       - name: Validate manifest (schema gate, blocks commit)
-        # See L53 step for mode-value rationale.
         if: steps.diff.outputs.changed == 'true'
         uses: cardinalby/schema-validator-action@v3
         with:
@@ -338,6 +176,9 @@ jobs:
       - name: Commit changes
         if: steps.diff.outputs.changed == 'true'
         id: commit
+        env:
+          # Prefer GitHub App token; fall back to GITHUB_TOKEN.
+          GIT_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -349,9 +190,10 @@ jobs:
             exit 0
           fi
           git commit -m "Sync ${{ steps.diff.outputs.total_new }} new starred repositories [skip ci]"
+          remote_url="https://x-access-token:${GIT_TOKEN}@github.com/${{ github.repository }}.git"
           pushed=false
           for attempt in 1 2 3 4 5; do
-            if git pull --rebase --autostash origin main && git push; then
+            if git pull --rebase --autostash "$remote_url" main && git push "$remote_url" HEAD:main; then
               pushed=true
               break
             fi
@@ -373,12 +215,15 @@ jobs:
           ARTIFACT_NAME: ${{ steps.source.outputs.artifact_name }}
           TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
           DIFF_CHANGED: ${{ steps.diff.outputs.changed }}
+          DESTRUCTIVE_REFUSED: ${{ steps.diff.outputs.destructive_refused }}
+          REMOVAL_RATIO: ${{ steps.diff.outputs.removal_ratio }}
           TOTAL_NEW: ${{ steps.diff.outputs.total_new }}
           TOTAL_REMOVED: ${{ steps.diff.outputs.total_removed }}
           TOTAL_UPDATED: ${{ steps.diff.outputs.total_updated }}
           TOTAL_REPOS: ${{ steps.diff.outputs.total_repos }}
           COMMIT_PUSHED: ${{ steps.commit.outputs.pushed }}
           COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
+          APP_TOKEN_USED: ${{ steps.app-token.outputs.token != '' }}
         run: |
           {
             echo "# 02 — Sync"
@@ -388,6 +233,7 @@ jobs:
             echo "- Trigger: \`${{ github.event_name }}\`"
             echo "- Triggering run: \`${TRIGGER_RUN_ID:-n/a}\`"
             echo "- Commit: \`${{ github.sha }}\`"
+            echo "- GitHub App token used for commit: \`${APP_TOKEN_USED:-false}\`"
             echo ""
             echo "## Inputs"
             echo "- Source: \`${INPUT_SOURCE:-unresolved}\`"
@@ -400,9 +246,18 @@ jobs:
             echo "- Removed: \`${TOTAL_REMOVED:-0}\`"
             echo "- Updated: \`${TOTAL_UPDATED:-0}\`"
             echo "- Total repos: \`${TOTAL_REPOS:-?}\`"
+            if [ -n "${REMOVAL_RATIO:-}" ]; then
+              echo "- Removal ratio: \`${REMOVAL_RATIO}\` (threshold 0.05)"
+            fi
+            if [ "${DESTRUCTIVE_REFUSED:-false}" = "true" ]; then
+              echo ""
+              echo "## ⚠ Destructive sync refused"
+              echo "Re-dispatch with input \`removal_override=true\` to bypass the 5% guard if the unstar event is genuine."
+            fi
             echo ""
             echo "## Gates"
             echo "- \`cardinalby/schema-validator-action@v3\` (mode: default) against \`schemas/repos-schema.json\` (existing + post-update; both block commit)"
+            echo "- \`src/sync/reconcile.ts\` 5% destructive-deletion guard (\`MANIFEST_REMOVAL_OVERRIDE=true\` to bypass)"
             echo ""
             echo "## Commit"
             echo "- Pushed: \`${COMMIT_PUSHED:-false}\`"

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ Thumbs.db
 *.temp
 .cache/
 yq
+
+# Local one-shot reproduction sandboxes (never committed).
+.tmp-repro/
+.tmp-*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,13 @@
 This file contains instructions for AI agents (and human contributors) working on this codebase.
 
 ## 1. Project Overview
-This is a **GitHub Actions-based automation system** for curating starred repositories.
-- **Core Logic**: Embedded in `.github/workflows/*.yml` (JavaScript via `actions/github-script`).
-- **Database**: `repos.yml` (YAML manifest). Two independent gates protect it: a **JSON Schema** gate (`schemas/repos-schema.json`) and a **taxonomy** gate (categories/tags must come from the closed set defined in `src/manifest/taxonomy.ts`).
-- **Local Build**: A small TypeScript toolchain in `src/` is used in CI (`00-ci.yml`) and is runnable locally via `pnpm test`, `pnpm validate`, and `pnpm repro:taxonomy`.
-- **Web Surface**: A Vite + React app under `web/` builds to `docs/` and is deployed to GitHub Pages by `04-build-site.yml`. A separate CI gate (`00b-web-ci.yml`) runs `npm ci`/`lint`/`build` on every PR + push to `main`.
+This is a **TypeScript control plane orchestrated by GitHub Actions** for curating starred repositories. Per issue #69, runtime policy lives in typed modules under `src/`; workflow YAML is orchestration only.
+- **Core logic**: typed modules under `src/auth/`, `src/fetch/`, `src/sync/`, `src/diagnostics/`, `src/generated/`, `src/gate/`, plus the existing `src/manifest/`. Workflows under `.github/workflows/` invoke these via `pnpm <script>` rather than embedding business logic in YAML/JavaScript.
+- **Single readiness command**: `pnpm gate` runs typecheck + test + validate + generated-artifact registry + actionlint, in that order, fail-fast. `00-ci.yml` calls `pnpm gate` as its primary gate.
+- **Auth model**: `src/auth/resolve-auth-mode.ts` is the source of truth for which credential drives which capability. Modes: `github_app` (preferred), `pat`, `public`, `github_token` (degraded), `disabled`. The resolver runs as `pnpm auth:doctor` (alias for `tsx src/auth/setup-doctor.ts`) and writes per-job outputs `auth_mode`, `star_source_user`, `star_fetch_auth`, `repo_write_auth`, `degraded`. See §8.
+- **Generated artifacts**: every committed artifact has a producer/consumer/policy entry in `src/generated/registry.ts`; `pnpm gate` checks each is present.
+- **Database**: `repos.yml` (YAML manifest). Two independent gates protect it: a **JSON Schema** gate (`schemas/repos-schema.json`, enforced by `cardinalby/schema-validator-action@v3`) and a **taxonomy** gate (`src/manifest/taxonomy.ts`).
+- **Web surface**: a Vite + React app under `web/` builds to `docs/` and is deployed to GitHub Pages by `04-build-site.yml`. A separate CI gate (`00b-web-ci.yml`) runs `npm ci`/`lint`/`build` on every PR + push to `main`.
 
 ## 2. Build, Test, and Validation
 
@@ -27,11 +29,18 @@ ajv validate -s schemas/repos-schema.json -d repos.yml             # schema (if 
 
 ### Local toolchain (Node / pnpm)
 - Install: `pnpm install` (lockfile is `pnpm-lock.yaml`, `lockfileVersion 9.0`; CI pins `pnpm@10.13.1`).
-- Unit tests: `pnpm test` (vitest, `vitest.config.ts`).
-- Taxonomy validator: `pnpm validate` (runs `src/cli-validate.ts`).
-- Taxonomy reproduction: `pnpm repro:taxonomy`.
-- Normalizer: `pnpm normalize` (in-place canonicalization of `repos.yml`).
-- The first three are what `.github/workflows/00-ci.yml` runs on every PR / push to `main`.
+- **Readiness check (use this first)**: `pnpm gate` — runs all sub-gates: typecheck, test, validate, generated-artifact registry, actionlint. Mirrors what CI runs.
+- Sub-gates (run individually):
+  - `pnpm typecheck` (`tsc --noEmit`)
+  - `pnpm test` (vitest)
+  - `pnpm validate` (taxonomy strict on `repos.yml`)
+  - `pnpm repro:taxonomy` (regenerates the failing fixture used by tests)
+  - `pnpm normalize` (in-place canonicalization of `repos.yml`)
+- Workflow CLIs (also invocable locally with `GH_TOKEN`):
+  - `pnpm auth:doctor` — print active auth mode + capability matrix.
+  - `pnpm fetch:stars` — full two-stage fetch into `.github-stars/data/fetched-stars-graphql.json`.
+  - `pnpm sync:stars` — reconcile `repos.yml` against the fetched JSON.
+- `00-ci.yml` runs `pnpm gate` as the primary gate; PRs and pushes to `main` must pass it.
 
 ### Running Workflows
 Actual workflow files in `.github/workflows/` (numbered, run in order via `workflow_run` chaining):
@@ -89,9 +98,16 @@ Trigger any workflow manually via the GitHub Actions tab (`workflow_dispatch`).
 - maintain clear instructions for the AI model (GPT-4o) in these prompts.
 
 ## 5. Directory Structure
-- `.github/workflows/`: Automation logic (numbered `00`–`05`, see §2).
+- `.github/workflows/`: Orchestration only. Workflows invoke `pnpm <script>` for any non-trivial logic.
 - `schemas/repos-schema.json`: JSON Schema, source of truth for `repos.yml`.
-- `queries/stars-query.graphql`: GraphQL query consumed by `01-fetch-stars`.
+- `queries/stars-list-query.graphql`: cheap pagination query (stage 1).
+- `queries/stars-metadata-fragment.graphql`: per-repo metadata fragment (stage 2).
+- `src/auth/`: auth mode types, resolver, setup-doctor.
+- `src/fetch/`: fetch-stars orchestrator + cli, list paginator, metadata batcher, partial-graphql handling, octokit client wrapper.
+- `src/sync/`: reconcile (with 5% destructive-deletion guard), manifest io, cli.
+- `src/diagnostics/`: evidence labels, $GITHUB_STEP_SUMMARY helpers.
+- `src/generated/registry.ts`: typed registry of every committed/artifacted output.
+- `src/gate/cli.ts`: `pnpm gate` runner (typecheck + test + validate + registry + actionlint).
 - `src/manifest/`: TypeScript loader/normalizer/validator for `repos.yml`.
 - `src/cli-validate.ts`, `src/cli-normalize.ts`, `src/repro-taxonomy.ts`: Local CLI entry points.
 - `fixtures/repos.invalid.yml`: Failing fixture used by `pnpm repro:taxonomy`.
@@ -106,7 +122,8 @@ Trigger any workflow manually via the GitHub Actions tab (`workflow_dispatch`).
 
 ```
 GitHub stars (per user)
-   │  graphql:`viewer { starredRepositories ... }` (queries/stars-query.graphql)
+   │  graphql: stage 1 cheap list (queries/stars-list-query.graphql)
+   │           + stage 2 per-repo metadata (queries/stars-metadata-fragment.graphql)
    ▼
 01-fetch-stars.yml (cron + workflow_dispatch)
    ├── writes  .github-stars/data/fetched-stars-graphql.json   (transient JSON)
@@ -152,18 +169,27 @@ files in `categories/` and `tags/` automatically.
 - **Free Tier**: Do not introduce paid dependencies or services.
 - **Idempotency**: Workflows should be safe to re-run.
 
-## 8. Token Model (star fetch)
+## 8. Auth model
 
-`01-fetch-stars` uses `secrets.STARS_TOKEN || secrets.GITHUB_TOKEN`.
+The auth resolver (`src/auth/resolve-auth-mode.ts`) is the source of truth — workflows do NOT use implicit `secrets.STARS_TOKEN || secrets.GITHUB_TOKEN` fallthroughs as the auth decision. Run `pnpm auth:doctor` to print the active mode, capability matrix, and missing-config list (no secret values are printed).
 
-- `STARS_TOKEN` is a Personal Access Token with `read:user` scope, owned
-  by the account whose stars you want to fetch. The default
-  `GITHUB_TOKEN` belongs to the workflow's identity, which fetches
-  stars for the wrong account in forks/orgs and may have insufficient
-  scope.
-- The workflow performs a `viewer { login }` auth probe up front. On
-  `Bad credentials` it fails fast with a remediation message; transient
-  5xx are retried with capped, jittered backoff.
-- If `STARS_TOKEN` is missing, the workflow falls back to
-  `GITHUB_TOKEN` and emits a warning in the job summary so the
-  intentional vs. accidental fallback is visible in the run record.
+**Critical invariant**: `repo_write_auth != star_fetch_auth`. The two roles use independent credential decisions because GitHub App installation tokens cannot enumerate `viewer.starredRepositories`.
+
+| Mode            | Purpose                                       | Credential source                        | Status               |
+|-----------------|-----------------------------------------------|------------------------------------------|----------------------|
+| `github_app`    | preferred repo write / commit                 | `vars.GH_APP_CLIENT_ID` + `secrets.GH_APP_PRIVATE_KEY` | preferred       |
+| `pat`           | authenticated user-star fetch                 | `secrets.STARS_TOKEN` (read:user scope)  | supported fallback   |
+| `public`        | public-only star catalog                      | no token; `vars.STAR_SOURCE_USER`        | supported fallback   |
+| `github_token`  | workflow identity fallback                    | built-in `secrets.GITHUB_TOKEN`          | degraded, loud       |
+| `disabled`      | no usable path                                | none                                     | fail-fast            |
+
+**Auto resolution priority** (when no `auth_mode` input is given):
+1. `github_app` if both client id + private key present
+2. `pat` if `STARS_TOKEN` present (degraded — App is preferred)
+3. `public` if `STAR_SOURCE_USER` set
+4. `github_token` if available (degraded — fetches the bot account's stars)
+5. `disabled`
+
+**App configuration**: when the App is installed and its credentials are present, `01-fetch` and `02-sync` mint short-lived installation tokens via `actions/create-github-app-token@v3` and use them for the commit/push step. Star fetch still uses `STARS_TOKEN` because installation tokens lack user context.
+
+**Diagnostics**: every workflow that touches auth surfaces `auth_mode`, `star_source_user`, `star_fetch_auth`, `repo_write_auth`, `degraded` in `$GITHUB_STEP_SUMMARY`. If you see `auth_mode=disabled` or `degraded=true` and didn't expect it, the doctor's `missing_config` field names which key is absent.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "gate": "tsx src/gate/cli.ts",
     "repro:taxonomy": "tsx src/repro-taxonomy.ts",
     "normalize": "tsx src/cli-normalize.ts",
-    "validate": "tsx src/cli-validate.ts"
+    "validate": "tsx src/cli-validate.ts",
+    "auth:doctor": "tsx src/auth/setup-doctor.ts",
+    "fetch:stars": "tsx src/fetch/cli.ts",
+    "sync:stars": "tsx src/sync/cli.ts"
   },
   "devDependencies": {
     "@exodus/schemasafe": "^1.3.0",
@@ -19,6 +24,10 @@
     "vitest": "^2.1.8"
   },
   "dependencies": {
+    "@octokit/auth-app": "^8.2.0",
+    "@octokit/core": "^7.0.6",
+    "@octokit/plugin-request-log": "^6.0.0",
+    "@octokit/plugin-retry": "^8.1.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "js-yaml": "^4.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@octokit/auth-app':
+        specifier: ^8.2.0
+        version: 8.2.0
+      '@octokit/core':
+        specifier: ^7.0.6
+        version: 7.0.6
+      '@octokit/plugin-request-log':
+        specifier: ^6.0.0
+        version: 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-retry':
+        specifier: ^8.1.0
+        version: 8.1.0(@octokit/core@7.0.6)
       ajv:
         specifier: ^8.17.1
         version: 8.18.0
@@ -339,6 +351,72 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@octokit/auth-app@8.2.0':
+    resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-app@9.0.3':
+    resolution: {integrity: sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-device@8.0.3':
+    resolution: {integrity: sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-user@6.0.2':
+    resolution: {integrity: sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.2':
+    resolution: {integrity: sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@8.1.0':
+    resolution: {integrity: sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.8':
+    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
@@ -533,6 +611,12 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -578,6 +662,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -598,6 +685,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -670,6 +760,10 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -682,6 +776,12 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -902,6 +1002,102 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@octokit/auth-app@8.2.0':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      toad-cache: 3.7.0
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@9.0.3':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@8.0.3':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@6.0.2':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.2':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-retry@8.1.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.8':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -1040,6 +1236,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  before-after-hook@4.0.0: {}
+
+  bottleneck@2.19.5: {}
+
   cac@6.7.14: {}
 
   chai@5.3.3:
@@ -1121,6 +1321,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-content-type-parse@3.0.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-uri@3.1.0: {}
@@ -1137,6 +1339,8 @@ snapshots:
       argparse: 2.0.1
 
   json-schema-traverse@1.0.0: {}
+
+  json-with-bigint@3.5.8: {}
 
   loupe@3.2.1: {}
 
@@ -1213,6 +1417,8 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  toad-cache@3.7.0: {}
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.3
@@ -1223,6 +1429,10 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  universal-github-app-jwt@2.2.2: {}
+
+  universal-user-agent@7.0.3: {}
 
   vite-node@2.1.9(@types/node@22.19.11):
     dependencies:

--- a/src/auth/auth-mode.ts
+++ b/src/auth/auth-mode.ts
@@ -1,0 +1,57 @@
+// Auth mode types for the github-stars control plane.
+//
+// Per issue #69 doctrine: repo_write_auth != star_fetch_auth.
+// One credential decision drives commits/PRs against this repo;
+// a separate decision drives the GraphQL star fetch.
+//
+// Modes are explicit and named; no implicit fallback. The resolver
+// in resolve-auth-mode.ts maps env+inputs -> ResolvedAuth, and the
+// workflow consumes the resolution via setup-doctor's typed output.
+
+export const AUTH_MODES = ['github_app', 'pat', 'public', 'github_token', 'disabled'] as const;
+export type AuthMode = (typeof AUTH_MODES)[number];
+
+/** Inputs to the resolver. All fields optional; resolver decides. */
+export type AuthResolverInputs = {
+  /** workflow_dispatch input or schedule default. 'auto' = resolver picks. */
+  requested_mode?: AuthMode | 'auto';
+  /** GitHub user whose stars are fetched. */
+  star_source_user?: string;
+
+  /** Secrets/vars surface (presence checked, never values printed). */
+  has_gh_app_client_id?: boolean;
+  has_gh_app_private_key?: boolean;
+  has_stars_token?: boolean;
+  has_github_token?: boolean;
+};
+
+/** What the resolver decides for one role (fetch vs write). */
+export type RoleAuth =
+  | { source: 'github_app' }
+  | { source: 'pat' }
+  | { source: 'public' }
+  | { source: 'github_token' }
+  | { source: 'none' };
+
+/** Final resolution. Workflow reads these outputs as job-level outputs. */
+export type ResolvedAuth = {
+  auth_mode: AuthMode;
+  star_source_user: string;
+  star_fetch_auth: RoleAuth;
+  repo_write_auth: RoleAuth;
+  /** True when a fallback was used because the preferred mode was unavailable. */
+  degraded: boolean;
+  /** Human-readable reason for the chosen mode (or for the fail). */
+  reason: string;
+  /** Names of required-but-missing config keys when auth_mode === 'disabled'. */
+  missing_config: string[];
+  /**
+   * Capability matrix the doctor surfaces in $GITHUB_STEP_SUMMARY.
+   * No values, only yes/no/blocked.
+   */
+  capabilities: {
+    can_mint_app_token: 'yes' | 'no' | 'blocked';
+    can_fetch_star_page: 'yes' | 'no' | 'blocked';
+    can_checkout_target_repo: 'yes' | 'no' | 'blocked';
+  };
+};

--- a/src/auth/resolve-auth-mode.test.ts
+++ b/src/auth/resolve-auth-mode.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAuthMode } from './resolve-auth-mode.js';
+
+const base = { star_source_user: 'primeinc' };
+
+describe('resolveAuthMode — auto', () => {
+  it('prefers github_app when both app credentials present', () => {
+    const r = resolveAuthMode({ ...base, has_gh_app_client_id: true, has_gh_app_private_key: true, has_stars_token: true });
+    expect(r.auth_mode).toBe('github_app');
+    expect(r.repo_write_auth.source).toBe('github_app');
+    expect(r.degraded).toBe(false);
+    // Star fetch under app mode falls through to PAT (apps can't read user.starredRepositories with installation tokens).
+    expect(r.star_fetch_auth.source).toBe('pat');
+  });
+
+  it('falls back to pat when only PAT is present', () => {
+    const r = resolveAuthMode({ ...base, has_stars_token: true });
+    expect(r.auth_mode).toBe('pat');
+    expect(r.degraded).toBe(true);
+    expect(r.star_fetch_auth.source).toBe('pat');
+    expect(r.repo_write_auth.source).toBe('pat');
+  });
+
+  it('falls back to public when only star_source_user is set', () => {
+    const r = resolveAuthMode({ ...base });
+    expect(r.auth_mode).toBe('public');
+    expect(r.degraded).toBe(true);
+    expect(r.star_fetch_auth.source).toBe('public');
+    // No write auth available in pure public mode.
+    expect(r.repo_write_auth.source).toBe('none');
+  });
+
+  it('uses github_token as last resort when no user is configured', () => {
+    const r = resolveAuthMode({ has_github_token: true });
+    expect(r.auth_mode).toBe('github_token');
+    expect(r.degraded).toBe(true);
+    expect(r.reason).toContain('GITHUB_TOKEN');
+  });
+
+  it('returns disabled when nothing usable', () => {
+    const r = resolveAuthMode({});
+    expect(r.auth_mode).toBe('disabled');
+    expect(r.capabilities.can_fetch_star_page).toBe('blocked');
+  });
+
+  it('public + github_token → public wins, write uses GITHUB_TOKEN', () => {
+    const r = resolveAuthMode({ ...base, has_github_token: true });
+    expect(r.auth_mode).toBe('public');
+    expect(r.repo_write_auth.source).toBe('github_token');
+  });
+});
+
+describe('resolveAuthMode — explicit modes', () => {
+  it('explicit github_app + missing private key → disabled with named gap', () => {
+    const r = resolveAuthMode({ ...base, requested_mode: 'github_app', has_gh_app_client_id: true });
+    expect(r.auth_mode).toBe('disabled');
+    expect(r.missing_config).toEqual(['GH_APP_PRIVATE_KEY']);
+    expect(r.capabilities.can_mint_app_token).toBe('blocked');
+  });
+
+  it('explicit pat + missing STARS_TOKEN → disabled with named gap', () => {
+    const r = resolveAuthMode({ ...base, requested_mode: 'pat' });
+    expect(r.auth_mode).toBe('disabled');
+    expect(r.missing_config).toEqual(['STARS_TOKEN']);
+  });
+
+  it('explicit public + no user → disabled', () => {
+    const r = resolveAuthMode({ requested_mode: 'public' });
+    expect(r.auth_mode).toBe('disabled');
+    expect(r.missing_config).toEqual(['STAR_SOURCE_USER']);
+  });
+
+  it('explicit pat with PAT present → pat (NOT degraded)', () => {
+    const r = resolveAuthMode({ ...base, requested_mode: 'pat', has_stars_token: true });
+    expect(r.auth_mode).toBe('pat');
+    expect(r.degraded).toBe(false);
+  });
+
+  it('explicit github_token still flagged degraded with reason', () => {
+    const r = resolveAuthMode({ ...base, requested_mode: 'github_token', has_github_token: true });
+    expect(r.auth_mode).toBe('github_token');
+    expect(r.degraded).toBe(true);
+  });
+
+  it('explicit disabled → disabled with reason', () => {
+    const r = resolveAuthMode({ requested_mode: 'disabled' });
+    expect(r.auth_mode).toBe('disabled');
+    expect(r.reason).toContain('disabled by request');
+  });
+});
+
+describe('resolveAuthMode — capabilities matrix', () => {
+  it('reports can_mint_app_token=yes only under github_app', () => {
+    const app = resolveAuthMode({ ...base, has_gh_app_client_id: true, has_gh_app_private_key: true });
+    expect(app.capabilities.can_mint_app_token).toBe('yes');
+    const pat = resolveAuthMode({ ...base, has_stars_token: true });
+    expect(pat.capabilities.can_mint_app_token).toBe('no');
+  });
+
+  it('reports can_checkout_target_repo=yes when any write auth is available', () => {
+    const r = resolveAuthMode({ ...base, has_stars_token: true });
+    expect(r.capabilities.can_checkout_target_repo).toBe('yes');
+  });
+
+  it('reports can_checkout_target_repo=blocked when no write auth at all', () => {
+    const r = resolveAuthMode({ ...base });
+    expect(r.capabilities.can_checkout_target_repo).toBe('blocked');
+  });
+});

--- a/src/auth/resolve-auth-mode.ts
+++ b/src/auth/resolve-auth-mode.ts
@@ -1,0 +1,147 @@
+// Pure resolver: env+inputs -> ResolvedAuth.
+//
+// Priority for `auto`:
+//   1. github_app  if both client id + private key present
+//   2. pat         if STARS_TOKEN present
+//   3. public      if star_source_user present
+//   4. github_token always degraded; only when nothing else applies
+//   5. disabled    when nothing usable
+//
+// When the user explicitly requests a mode, only that mode is considered;
+// missing config -> disabled with explicit missing_config list (never silent fallback).
+
+import type { AuthResolverInputs, ResolvedAuth, RoleAuth } from './auth-mode.js';
+
+const NO_AUTH: RoleAuth = { source: 'none' };
+
+export function resolveAuthMode(inputs: AuthResolverInputs): ResolvedAuth {
+  const star_source_user = (inputs.star_source_user || '').trim();
+  const requested = inputs.requested_mode || 'auto';
+
+  if (requested !== 'auto') {
+    return resolveExplicit(requested, inputs, star_source_user);
+  }
+
+  if (inputs.has_gh_app_client_id && inputs.has_gh_app_private_key) {
+    return ok('github_app', star_source_user, inputs, false, 'preferred mode (GitHub App configured)');
+  }
+  if (inputs.has_stars_token) {
+    return ok('pat', star_source_user, inputs, true, 'STARS_TOKEN present, GitHub App not configured');
+  }
+  if (star_source_user) {
+    return ok('public', star_source_user, inputs, true, 'no PAT and no App; falling back to public source');
+  }
+  if (inputs.has_github_token) {
+    return ok('github_token', star_source_user, inputs, true,
+      'last-resort: GITHUB_TOKEN identity will be used; this fetches the bot account stars, not the configured user');
+  }
+  return disabled(inputs, 'no usable credentials and no STAR_SOURCE_USER configured');
+}
+
+function resolveExplicit(mode: ResolvedAuth['auth_mode'], inputs: AuthResolverInputs, user: string): ResolvedAuth {
+  switch (mode) {
+    case 'github_app': {
+      const missing: string[] = [];
+      if (!inputs.has_gh_app_client_id) missing.push('GH_APP_CLIENT_ID');
+      if (!inputs.has_gh_app_private_key) missing.push('GH_APP_PRIVATE_KEY');
+      if (missing.length) return disabled(inputs, `github_app explicitly requested but missing: ${missing.join(', ')}`, missing);
+      return ok('github_app', user, inputs, false, 'github_app explicitly requested');
+    }
+    case 'pat': {
+      if (!inputs.has_stars_token) return disabled(inputs, 'pat explicitly requested but STARS_TOKEN missing', ['STARS_TOKEN']);
+      return ok('pat', user, inputs, false, 'pat explicitly requested');
+    }
+    case 'public': {
+      if (!user) return disabled(inputs, 'public explicitly requested but STAR_SOURCE_USER missing', ['STAR_SOURCE_USER']);
+      return ok('public', user, inputs, false, 'public explicitly requested');
+    }
+    case 'github_token': {
+      if (!inputs.has_github_token) return disabled(inputs, 'github_token explicitly requested but no GITHUB_TOKEN available', ['GITHUB_TOKEN']);
+      return ok('github_token', user, inputs, true, 'github_token explicitly requested (degraded)');
+    }
+    case 'disabled':
+      return disabled(inputs, 'auth explicitly disabled by request');
+  }
+}
+
+function ok(
+  mode: Exclude<ResolvedAuth['auth_mode'], 'disabled'>,
+  user: string,
+  inputs: AuthResolverInputs,
+  degraded: boolean,
+  reason: string
+): ResolvedAuth {
+  const fetch_auth = fetchAuthFor(mode, inputs);
+  const write_auth = writeAuthFor(mode, inputs);
+  return {
+    auth_mode: mode,
+    star_source_user: user,
+    star_fetch_auth: fetch_auth,
+    repo_write_auth: write_auth,
+    degraded,
+    reason,
+    missing_config: [],
+    capabilities: {
+      can_mint_app_token: mode === 'github_app' ? 'yes' : 'no',
+      // 'blocked' = required credential missing for the configured mode.
+      // 'no'      = mode does not provide this capability (e.g. github_token
+      //             cannot mint app tokens because that is structural).
+      can_fetch_star_page: fetch_auth.source === 'none' ? 'blocked' : 'yes',
+      can_checkout_target_repo: write_auth.source === 'none' ? 'blocked' : 'yes',
+    },
+  };
+}
+
+function disabled(inputs: AuthResolverInputs, reason: string, missing_config: string[] = []): ResolvedAuth {
+  return {
+    auth_mode: 'disabled',
+    star_source_user: (inputs.star_source_user || '').trim(),
+    star_fetch_auth: NO_AUTH,
+    repo_write_auth: inputs.has_github_token ? { source: 'github_token' } : NO_AUTH,
+    degraded: true,
+    reason,
+    missing_config,
+    capabilities: {
+      can_mint_app_token: missing_config.length ? 'blocked' : 'no',
+      can_fetch_star_page: 'blocked',
+      can_checkout_target_repo: inputs.has_github_token ? 'yes' : 'blocked',
+    },
+  };
+}
+
+/**
+ * Star fetch and repo write may use different sources.
+ * github_app for repo write is preferred; star fetch under app mode
+ * still needs a user-context token, so it falls through to PAT or public.
+ */
+function fetchAuthFor(mode: Exclude<ResolvedAuth['auth_mode'], 'disabled'>, inputs: AuthResolverInputs): RoleAuth {
+  switch (mode) {
+    case 'github_app':
+      // App installation tokens cannot enumerate user.starredRepositories;
+      // need a user-context token. Prefer PAT; fall back to public if a user is set.
+      if (inputs.has_stars_token) return { source: 'pat' };
+      if (inputs.star_source_user) return { source: 'public' };
+      return NO_AUTH;
+    case 'pat':
+      return { source: 'pat' };
+    case 'public':
+      return { source: 'public' };
+    case 'github_token':
+      return { source: 'github_token' };
+  }
+}
+
+function writeAuthFor(mode: Exclude<ResolvedAuth['auth_mode'], 'disabled'>, inputs: AuthResolverInputs): RoleAuth {
+  switch (mode) {
+    case 'github_app':
+      return { source: 'github_app' };
+    case 'pat':
+      // PAT can write too; preferred over the workflow identity for commits.
+      return { source: 'pat' };
+    case 'public':
+      // Public-mode fetch still needs *something* to commit results back.
+      return inputs.has_github_token ? { source: 'github_token' } : NO_AUTH;
+    case 'github_token':
+      return { source: 'github_token' };
+  }
+}

--- a/src/auth/setup-doctor.ts
+++ b/src/auth/setup-doctor.ts
@@ -1,0 +1,121 @@
+// setup-doctor — prints the resolved auth matrix and writes typed outputs.
+//
+// Run via `pnpm auth:doctor` or directly in a workflow step. Reads env:
+//   AUTH_MODE_REQUEST  (workflow input; default 'auto')
+//   STAR_SOURCE_USER   (vars.STAR_SOURCE_USER or default)
+//   GH_APP_CLIENT_ID   (vars; presence only)
+//   GH_APP_PRIVATE_KEY (secrets; presence only)
+//   STARS_TOKEN        (secrets; presence only)
+//   GITHUB_TOKEN       (built-in; presence only)
+//
+// Writes to:
+//   stdout       — JSON resolution (one line)
+//   $GITHUB_STEP_SUMMARY — markdown matrix (presence/status, never values)
+//   $GITHUB_OUTPUT       — auth_mode, star_source_user, star_fetch_auth,
+//                          repo_write_auth, degraded, missing_config (joined)
+//
+// Exits non-zero only when auth_mode === 'disabled' AND the doctor was
+// invoked with --strict. Without --strict, a disabled mode is reported
+// but the workflow keeps running so 02-Sync can still produce
+// downstream-readable diagnostics.
+
+import { appendFileSync, existsSync } from 'node:fs';
+import process from 'node:process';
+import { resolveAuthMode } from './resolve-auth-mode.js';
+import type { AuthMode, ResolvedAuth } from './auth-mode.js';
+
+const VALID_MODES: ReadonlyArray<AuthMode | 'auto'> = [
+  'auto', 'github_app', 'pat', 'public', 'github_token', 'disabled',
+];
+
+function readEnv(): Parameters<typeof resolveAuthMode>[0] {
+  const requested = (process.env.AUTH_MODE_REQUEST || 'auto').trim() as AuthMode | 'auto';
+  if (!VALID_MODES.includes(requested)) {
+    throw new Error(`AUTH_MODE_REQUEST=${requested} is not one of: ${VALID_MODES.join(', ')}`);
+  }
+  return {
+    requested_mode: requested,
+    star_source_user: process.env.STAR_SOURCE_USER || '',
+    has_gh_app_client_id: nonEmpty(process.env.GH_APP_CLIENT_ID),
+    has_gh_app_private_key: nonEmpty(process.env.GH_APP_PRIVATE_KEY),
+    has_stars_token: nonEmpty(process.env.STARS_TOKEN),
+    has_github_token: nonEmpty(process.env.GITHUB_TOKEN),
+  };
+}
+
+function nonEmpty(v: string | undefined): boolean {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+export function renderSummary(r: ResolvedAuth): string {
+  const lines: string[] = [];
+  lines.push('## Auth setup-doctor');
+  lines.push('');
+  lines.push(`- **Auth mode**: \`${r.auth_mode}\`${r.degraded ? ' _(degraded)_' : ''}`);
+  lines.push(`- **Star source user**: \`${r.star_source_user || '(unset)'}\``);
+  lines.push(`- **Star fetch auth**: \`${r.star_fetch_auth.source}\``);
+  lines.push(`- **Repo write auth**: \`${r.repo_write_auth.source}\``);
+  lines.push(`- **Reason**: ${r.reason}`);
+  if (r.missing_config.length) {
+    lines.push(`- **Missing**: ${r.missing_config.map(m => `\`${m}\``).join(', ')}`);
+  }
+  lines.push('');
+  lines.push('### Capability matrix');
+  lines.push('');
+  lines.push('| Capability | Status |');
+  lines.push('|---|---|');
+  lines.push(`| Mint GitHub App installation token | \`${r.capabilities.can_mint_app_token}\` |`);
+  lines.push(`| Fetch a star page              | \`${r.capabilities.can_fetch_star_page}\` |`);
+  lines.push(`| Checkout / commit to target repo | \`${r.capabilities.can_checkout_target_repo}\` |`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function writeJobOutputs(r: ResolvedAuth): void {
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) return;
+  const lines = [
+    `auth_mode=${r.auth_mode}`,
+    `star_source_user=${r.star_source_user}`,
+    `star_fetch_auth=${r.star_fetch_auth.source}`,
+    `repo_write_auth=${r.repo_write_auth.source}`,
+    `degraded=${r.degraded}`,
+    `missing_config=${r.missing_config.join(',')}`,
+    `reason=${oneLine(r.reason)}`,
+  ];
+  appendFileSync(out, lines.join('\n') + '\n');
+}
+
+function writeSummary(md: string): void {
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (!summary) return;
+  if (!existsSync(summary)) return;
+  appendFileSync(summary, md + '\n');
+}
+
+function oneLine(s: string): string {
+  return s.replace(/[\r\n]+/g, ' ').trim();
+}
+
+function main(): void {
+  const strict = process.argv.includes('--strict');
+  const inputs = readEnv();
+  const r = resolveAuthMode(inputs);
+
+  // Always emit JSON to stdout for programmatic consumers.
+  process.stdout.write(JSON.stringify(r, null, 2) + '\n');
+
+  // Markdown summary for humans reading the run page.
+  writeSummary(renderSummary(r));
+
+  // Structured outputs for downstream workflow steps.
+  writeJobOutputs(r);
+
+  if (r.auth_mode === 'disabled' && strict) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('setup-doctor.ts')) {
+  main();
+}

--- a/src/diagnostics/evidence.ts
+++ b/src/diagnostics/evidence.ts
@@ -1,0 +1,27 @@
+// Evidence labels per issue #69 doctrine. The labels are not decorative —
+// callers in workflow summaries and PR comments must use them when
+// claiming a fact about a run.
+
+export const EVIDENCE_LABELS = [
+  'direct',
+  'weak_inference',
+  'unsupported',
+  'blocked',
+  'contradicted',
+  'na',
+] as const;
+
+export type EvidenceLabel = (typeof EVIDENCE_LABELS)[number];
+
+export const EVIDENCE_PREFIX: Record<EvidenceLabel, string> = {
+  direct: 'Direct evidence:',
+  weak_inference: 'Weak inference:',
+  unsupported: 'Unsupported:',
+  blocked: 'Blocked:',
+  contradicted: 'Contradicted:',
+  na: 'N/A candidate:',
+};
+
+export function labeled(label: EvidenceLabel, body: string): string {
+  return `${EVIDENCE_PREFIX[label]} ${body}`;
+}

--- a/src/diagnostics/summary.ts
+++ b/src/diagnostics/summary.ts
@@ -1,0 +1,25 @@
+// $GITHUB_STEP_SUMMARY writer.
+// Workflow steps call appendSummary(...) to add evidence-labeled lines.
+
+import { appendFileSync, existsSync } from 'node:fs';
+import process from 'node:process';
+
+export function appendSummary(markdown: string): void {
+  const target = process.env.GITHUB_STEP_SUMMARY;
+  if (!target) return;
+  if (!existsSync(target)) return;
+  appendFileSync(target, markdown + '\n');
+}
+
+export function summaryHeading(level: number, text: string): string {
+  const hashes = '#'.repeat(Math.min(Math.max(level, 1), 6));
+  return `${hashes} ${text}`;
+}
+
+export function summaryTable(rows: ReadonlyArray<ReadonlyArray<string>>): string {
+  if (rows.length === 0) return '';
+  const [header, ...body] = rows;
+  const sep = header.map(() => '---');
+  const fmt = (r: ReadonlyArray<string>) => `| ${r.join(' | ')} |`;
+  return [fmt(header), fmt(sep), ...body.map(fmt)].join('\n');
+}

--- a/src/fetch/cli.ts
+++ b/src/fetch/cli.ts
@@ -1,0 +1,112 @@
+// CLI: invoked by .github/workflows/01-fetch-stars.yml as the single
+// fetch step. Replaces the prior actions/github-script JS blob.
+//
+// Reads env (no positional args):
+//   GH_TOKEN              token for star-fetch (required)
+//   RESUME_CURSOR         optional resume cursor (workflow_dispatch input)
+//   LIST_QUERY_PATH       default queries/stars-list-query.graphql
+//   METADATA_FRAGMENT_PATH default queries/stars-metadata-fragment.graphql
+//   OUTPUT_FILE           default .github-stars/data/fetched-stars-graphql.json
+//   METADATA_BATCH_SIZE   default 25
+//
+// Writes:
+//   OUTPUT_FILE  — JSON array of FetchedRepo
+//   $GITHUB_OUTPUT — total_repos, archived_count, fork_count,
+//                    no_description_count, output_file, output_bytes,
+//                    partial_failure_reason, resume_cursor, pages_fetched,
+//                    batches_fetched, blocked_orgs (csv)
+//   stderr  — info/warning lines for the runner log
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync, appendFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import process from 'node:process';
+import { createOctokit } from './octokit-client.js';
+import { fetchStars } from './fetch-stars.js';
+import { DEFAULT_METADATA_BATCH_SIZE } from './metadata-batcher.js';
+
+function envOrDefault(key: string, dflt: string): string {
+  const v = process.env[key];
+  return v && v.trim() ? v.trim() : dflt;
+}
+
+function setOutput(line: string): void {
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) return;
+  appendFileSync(out, line + '\n');
+}
+
+async function main(): Promise<void> {
+  const token = process.env.GH_TOKEN;
+  if (!token) {
+    console.error('GH_TOKEN env required for src/fetch/cli.ts');
+    process.exit(2);
+  }
+
+  const LIST_QUERY_PATH = envOrDefault('LIST_QUERY_PATH', 'queries/stars-list-query.graphql');
+  const FRAGMENT_PATH = envOrDefault('METADATA_FRAGMENT_PATH', 'queries/stars-metadata-fragment.graphql');
+  const OUTPUT_FILE = envOrDefault('OUTPUT_FILE', '.github-stars/data/fetched-stars-graphql.json');
+  const BATCH_SIZE = parseInt(envOrDefault('METADATA_BATCH_SIZE', String(DEFAULT_METADATA_BATCH_SIZE)), 10);
+  const resumeCursor = (process.env.RESUME_CURSOR || '').trim() || null;
+
+  for (const p of [LIST_QUERY_PATH, FRAGMENT_PATH]) {
+    if (!existsSync(p)) {
+      console.error(`Required query file not found: ${p}`);
+      process.exit(2);
+    }
+  }
+  const listQuery = readFileSync(LIST_QUERY_PATH, 'utf8');
+  const metadataFragment = readFileSync(FRAGMENT_PATH, 'utf8');
+
+  const octokit = createOctokit({ token, retries: 5 });
+
+  const log = (m: string) => process.stderr.write(m + '\n');
+  const warn = (m: string) => process.stderr.write(`::warning::${m}\n`);
+
+  const result = await fetchStars({
+    octokit,
+    listQuery,
+    metadataFragment,
+    resumeCursor,
+    batchSize: BATCH_SIZE,
+    log,
+    warn,
+  });
+
+  // Write output JSON regardless of partial-failure so it remains uploadable.
+  mkdirSync(dirname(OUTPUT_FILE), { recursive: true });
+  writeFileSync(OUTPUT_FILE, JSON.stringify(result.repos, null, 2));
+  const outputBytes = statSync(OUTPUT_FILE).size;
+
+  const archived = result.repos.filter((r) => r.archived).length;
+  const forks = result.repos.filter((r) => r.fork).length;
+  const noDesc = result.repos.filter((r) => !r.description).length;
+
+  log(`Total: ${result.repos.length} repositories — list pages=${result.pageCount} metadata batches=${result.batchCount}`);
+  log(`Archived: ${archived}, Forks: ${forks}, No description: ${noDesc}`);
+
+  setOutput(`total_repos=${result.repos.length}`);
+  setOutput(`archived_count=${archived}`);
+  setOutput(`fork_count=${forks}`);
+  setOutput(`no_description_count=${noDesc}`);
+  setOutput(`output_file=${OUTPUT_FILE}`);
+  setOutput(`output_bytes=${outputBytes}`);
+  setOutput(`partial_failure_reason=${result.partialFailureReason}`);
+  setOutput(`pages_fetched=${result.pageCount}`);
+  setOutput(`batches_fetched=${result.batchCount}`);
+  setOutput(`resume_cursor=${result.lastEndCursor ?? ''}`);
+  setOutput(`blocked_orgs=${result.inaccessibleOrgs.join(',')}`);
+
+  if (result.partialFailureReason) {
+    console.error(
+      `::error::Star fetch incomplete: ${result.partialFailureReason}. ` +
+        `Wrote ${result.repos.length} partial repos to ${OUTPUT_FILE} (${outputBytes} bytes). ` +
+        `To resume, dispatch with input resume_cursor='${result.lastEndCursor ?? ''}'.`
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`fetch-stars cli crashed: ${err?.stack ?? err}`);
+  process.exit(1);
+});

--- a/src/fetch/fetch-stars.ts
+++ b/src/fetch/fetch-stars.ts
@@ -1,0 +1,87 @@
+// Orchestrates list pagination + metadata batches.
+
+import { paginateStarList } from './list-paginator.js';
+import { fetchMetadataInBatches, DEFAULT_METADATA_BATCH_SIZE } from './metadata-batcher.js';
+import type { OctokitClient } from './octokit-client.js';
+import type { FetchOutcome } from './types.js';
+
+export type FetchStarsOptions = {
+  octokit: OctokitClient;
+  listQuery: string;
+  metadataFragment: string;
+  resumeCursor: string | null;
+  batchSize?: number;
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+};
+
+export async function fetchStars(opts: FetchStarsOptions): Promise<FetchOutcome> {
+  const log = opts.log ?? (() => {});
+  const warn = opts.warn ?? (() => {});
+
+  log('Stage 1: paginating star list (cheap query)...');
+  const stage1 = await paginateStarList({
+    octokit: opts.octokit,
+    query: opts.listQuery,
+    resumeCursor: opts.resumeCursor,
+    log,
+    warn,
+  });
+
+  if (stage1.partialFailureReason) {
+    return {
+      repos: [],
+      pageCount: stage1.pageCount,
+      batchCount: 0,
+      lastEndCursor: stage1.lastEndCursor,
+      inaccessibleOrgs: [...stage1.inaccessibleOrgs].sort(),
+      partialFailureReason: stage1.partialFailureReason,
+    };
+  }
+
+  log(`Stage 1 done: ${stage1.list.length} public stars across ${stage1.pageCount} pages.`);
+  if (stage1.inaccessibleOrgs.size > 0) {
+    warn(
+      `Skipped ${stage1.inaccessibleOrgs.size} orgs that block classic-PAT access: ` +
+        `${[...stage1.inaccessibleOrgs].sort().join(', ')}. ` +
+        `To include them, switch to a fine-grained PAT or GitHub App.`
+    );
+  }
+
+  log(`Stage 2: fetching metadata in batches of ${opts.batchSize ?? DEFAULT_METADATA_BATCH_SIZE}...`);
+  const stage2 = await fetchMetadataInBatches({
+    octokit: opts.octokit,
+    fragment: opts.metadataFragment,
+    list: stage1.list,
+    batchSize: opts.batchSize,
+    log,
+    warn,
+  });
+
+  // Combine blocked-org sets across stages.
+  const blocked = new Set<string>([...stage1.inaccessibleOrgs, ...stage2.blockedOrgs]);
+
+  // Tolerance: if stage2 left repos unfetched, only treat as success when the
+  // gap matches the count of skipped blocked-org repos (≤10% tolerance).
+  let partialFailureReason = stage2.partialFailureReason;
+  const gap = stage1.list.length - stage2.repos.length;
+  if (!partialFailureReason && gap > 0) {
+    if (blocked.size > 0 && gap < stage1.list.length * 0.1) {
+      log(`Stage 2 expected gap: ${gap} repos in classic-PAT-blocked orgs (${blocked.size} orgs).`);
+    } else {
+      partialFailureReason = `metadata_incomplete_${stage2.repos.length}_of_${stage1.list.length}_gap=${gap}`;
+      warn(
+        `Stage 2 left ${gap} repos unfetched, more than the ${blocked.size} blocked orgs explain.`
+      );
+    }
+  }
+
+  return {
+    repos: stage2.repos,
+    pageCount: stage1.pageCount,
+    batchCount: stage2.batchCount,
+    lastEndCursor: stage1.lastEndCursor,
+    inaccessibleOrgs: [...blocked].sort(),
+    partialFailureReason,
+  };
+}

--- a/src/fetch/list-paginator.test.ts
+++ b/src/fetch/list-paginator.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { paginateStarList } from './list-paginator.js';
+
+const QUERY = 'query($cursor: String) { viewer { starredRepositories(after: $cursor) { __typename } } }';
+
+function fakeOctokit(pages: Array<unknown>) {
+  let callIndex = 0;
+  return {
+    graphql: vi.fn(async (_q: string, _vars: unknown) => {
+      const page = pages[callIndex++];
+      if (page instanceof Error) throw page;
+      return page;
+    }),
+  } as unknown as Parameters<typeof paginateStarList>[0]['octokit'];
+}
+
+describe('paginateStarList', () => {
+  it('walks pageInfo.hasNextPage to completion and excludes private repos', async () => {
+    const oct = fakeOctokit([
+      {
+        viewer: {
+          starredRepositories: {
+            edges: [
+              { node: { nameWithOwner: 'a/b', isPrivate: false }, starredAt: '2025-01-01T00:00:00Z' },
+              { node: { nameWithOwner: 'c/d', isPrivate: true }, starredAt: '2025-01-02T00:00:00Z' },
+            ],
+            pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+            totalCount: 3,
+          },
+        },
+      },
+      {
+        viewer: {
+          starredRepositories: {
+            edges: [
+              { node: { nameWithOwner: 'e/f', isPrivate: false }, starredAt: '2025-01-03T00:00:00Z' },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: 'cursor-2' },
+            totalCount: 3,
+          },
+        },
+      },
+    ]);
+    const r = await paginateStarList({ octokit: oct, query: QUERY, resumeCursor: null });
+    expect(r.pageCount).toBe(2);
+    expect(r.list).toEqual([
+      { repo: 'a/b', user_starred_at: '2025-01-01T00:00:00Z' },
+      { repo: 'e/f', user_starred_at: '2025-01-03T00:00:00Z' },
+    ]);
+    expect(r.partialFailureReason).toBe('');
+    expect(r.lastEndCursor).toBe('cursor-2');
+  });
+
+  it('extracts partial data when graphql throws an org-blocked error', async () => {
+    const orgBlockedErr = Object.assign(new Error('Request failed'), {
+      data: {
+        viewer: {
+          starredRepositories: {
+            edges: [{ node: { nameWithOwner: 'x/y', isPrivate: false }, starredAt: '2025-01-04T00:00:00Z' }],
+            pageInfo: { hasNextPage: false, endCursor: 'cursor-end' },
+            totalCount: 1,
+          },
+        },
+      },
+      errors: [{ message: '`acme-corp` forbids access via a personal access token (classic).' }],
+    });
+    const oct = fakeOctokit([orgBlockedErr]);
+    const warns: string[] = [];
+    const r = await paginateStarList({ octokit: oct, query: QUERY, resumeCursor: null, warn: (m) => warns.push(m) });
+    expect(r.list).toEqual([{ repo: 'x/y', user_starred_at: '2025-01-04T00:00:00Z' }]);
+    expect([...r.inaccessibleOrgs]).toEqual(['acme-corp']);
+    expect(r.partialFailureReason).toBe('');
+    expect(warns[0]).toContain('partial response');
+  });
+
+  it('hard-fails when error has no extractable data', async () => {
+    const oct = fakeOctokit([Object.assign(new Error('502'), { status: 502 })]);
+    const r = await paginateStarList({ octokit: oct, query: QUERY, resumeCursor: null });
+    expect(r.partialFailureReason).toContain('list_error_at_page_1');
+    expect(r.partialFailureReason).toContain('status=502');
+    expect(r.list).toEqual([]);
+  });
+
+  it('resumes from the provided cursor', async () => {
+    const oct = fakeOctokit([
+      {
+        viewer: {
+          starredRepositories: {
+            edges: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+            totalCount: 0,
+          },
+        },
+      },
+    ]);
+    const r = await paginateStarList({ octokit: oct, query: QUERY, resumeCursor: 'mid-cursor' });
+    expect(oct.graphql).toHaveBeenCalledWith(QUERY, { cursor: 'mid-cursor' });
+    expect(r.pageCount).toBe(1);
+  });
+});

--- a/src/fetch/list-paginator.ts
+++ b/src/fetch/list-paginator.ts
@@ -1,0 +1,107 @@
+// Stage 1: cheap pagination of viewer.starredRepositories.
+// Per GitHub's published guidance — refs/github/docs/.../
+// rate-limits-and-query-limits-for-the-graphql-api.md L286-294
+// (10s timeout) and L308-316 ("Split large queries"), and the
+// pagination guide L49 ("request fewer items if your query touches
+// a lot of data") — we intentionally fetch only nameWithOwner +
+// isPrivate + starredAt at first:100. Local repro: <3.5s/page.
+
+import type { OctokitClient } from './octokit-client.js';
+import type { StarListEntry } from './types.js';
+import { classifyPartial, errorMessage, errorStatus, isBadCredentials } from './partial-graphql.js';
+
+export type ListPageResult = {
+  edges: Array<{ node: { nameWithOwner: string; isPrivate: boolean }; starredAt: string }>;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  totalCount: number;
+};
+
+export type ListPaginationOutcome = {
+  list: StarListEntry[];
+  pageCount: number;
+  lastEndCursor: string | null;
+  inaccessibleOrgs: Set<string>;
+  partialFailureReason: string;
+};
+
+export type ListPaginationOptions = {
+  octokit: OctokitClient;
+  query: string;
+  resumeCursor: string | null;
+  /** Logger; default no-op. Useful in tests. */
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+};
+
+export const BAD_CREDENTIALS_ERROR =
+  'Authentication failed: Bad credentials. ' +
+  'The configured token is expired, revoked, or insufficient. ' +
+  'See setup-doctor output for the active auth_mode and missing_config.';
+
+export async function paginateStarList(opts: ListPaginationOptions): Promise<ListPaginationOutcome> {
+  const log = opts.log ?? (() => {});
+  const warn = opts.warn ?? (() => {});
+
+  const list: StarListEntry[] = [];
+  const inaccessibleOrgs = new Set<string>();
+  let pageCount = 0;
+  let cursor: string | null = opts.resumeCursor;
+  let lastEndCursor: string | null = opts.resumeCursor;
+  let hasNextPage = true;
+  let partialFailureReason = '';
+
+  while (hasNextPage) {
+    pageCount++;
+    let page: ListPageResult | null = null;
+
+    try {
+      const response = await opts.octokit.graphql<{ viewer: { starredRepositories: ListPageResult } }>(
+        opts.query,
+        { cursor }
+      );
+      page = response.viewer.starredRepositories;
+    } catch (error: unknown) {
+      if (isBadCredentials(error)) {
+        partialFailureReason = `bad_credentials_at_page_${pageCount}`;
+        warn(BAD_CREDENTIALS_ERROR);
+        break;
+      }
+      const partial = classifyPartial(error);
+      const partialList = (partial?.data as { viewer?: { starredRepositories?: ListPageResult } } | null)
+        ?.viewer?.starredRepositories ?? null;
+      if (partialList) {
+        page = partialList;
+        for (const org of partial!.blockedOrgs) inaccessibleOrgs.add(org);
+        warn(
+          `page ${pageCount}: partial response (${partial!.blockedOrgs.length} blocked, ` +
+            `${partial!.otherErrors.length} other; continuing). ` +
+            (partial!.otherErrors[0] ? `Sample: ${partial!.otherErrors[0]}` : '')
+        );
+      } else {
+        partialFailureReason =
+          `list_error_at_page_${pageCount}_after_${list.length}_repos_status=${errorStatus(error)}_msg=${errorMessage(error)}`;
+        warn(
+          `Stage 1 list query failed at page ${pageCount}: ${errorMessage(error)}. ` +
+            `Cursor for resume: ${lastEndCursor ?? 'null'}.`
+        );
+        break;
+      }
+    }
+
+    if (!page) break;
+
+    for (const edge of page.edges ?? []) {
+      if (edge?.node && !edge.node.isPrivate) {
+        list.push({ repo: edge.node.nameWithOwner, user_starred_at: edge.starredAt });
+      }
+    }
+    lastEndCursor = page.pageInfo.endCursor;
+    hasNextPage = page.pageInfo.hasNextPage;
+    cursor = lastEndCursor;
+    if (pageCount % 5 === 0) {
+      log(`  list page ${pageCount}: total=${list.length}/${page.totalCount}`);
+    }
+  }
+
+  return { list, pageCount, lastEndCursor, inaccessibleOrgs, partialFailureReason };
+}

--- a/src/fetch/metadata-batcher.test.ts
+++ b/src/fetch/metadata-batcher.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { buildBatchQuery } from './metadata-batcher.js';
+
+const FRAGMENT = `fragment RepoMetadata on Repository { isArchived }`;
+
+describe('buildBatchQuery', () => {
+  it('produces variable declarations and aliases for each batch item', () => {
+    const q = buildBatchQuery(
+      [
+        { owner: 'a', name: 'b' },
+        { owner: 'c', name: 'd' },
+      ],
+      FRAGMENT
+    );
+    expect(q).toContain('$o0: String!, $n0: String!');
+    expect(q).toContain('$o1: String!, $n1: String!');
+    expect(q).toContain('r0: repository(owner: $o0, name: $n0) { ...RepoMetadata }');
+    expect(q).toContain('r1: repository(owner: $o1, name: $n1) { ...RepoMetadata }');
+    expect(q.startsWith(FRAGMENT)).toBe(true);
+  });
+
+  it('handles a single-repo batch', () => {
+    const q = buildBatchQuery([{ owner: 'a', name: 'b' }], FRAGMENT);
+    expect(q).toContain('$o0: String!, $n0: String!');
+    expect(q).toContain('r0: repository(owner: $o0, name: $n0) { ...RepoMetadata }');
+    expect(q).not.toContain('$o1');
+  });
+});

--- a/src/fetch/metadata-batcher.ts
+++ b/src/fetch/metadata-batcher.ts
@@ -1,0 +1,154 @@
+// Stage 2: per-repo metadata via aliased GraphQL batches.
+// One request fetches N repos by aliasing r0..rN-1, all sharing one
+// fragment. Local repro: 25 repos / batch / ~3.4s.
+
+import type { OctokitClient } from './octokit-client.js';
+import type { FetchedRepo, StarListEntry } from './types.js';
+import { classifyPartial, errorMessage, errorStatus, isBadCredentials } from './partial-graphql.js';
+import { BAD_CREDENTIALS_ERROR } from './list-paginator.js';
+
+export const DEFAULT_METADATA_BATCH_SIZE = 25;
+
+type RepoNode = {
+  description: string | null;
+  primaryLanguage: { name: string } | null;
+  repositoryTopics: { nodes: Array<{ topic: { name: string } }> };
+  isArchived: boolean;
+  isFork: boolean;
+  isPrivate: boolean;
+  stargazerCount: number;
+  forkCount: number;
+  updatedAt: string;
+  pushedAt: string;
+  diskUsage: number | null;
+  owner: { avatarUrl: string };
+  url: string;
+  defaultBranchRef: { name: string; target: { oid: string } | null } | null;
+  homepageUrl: string | null;
+  isMirror: boolean;
+  mirrorUrl: string | null;
+  licenseInfo: { spdxId: string | null } | null;
+  latestRelease: { tagName: string; publishedAt: string } | null;
+};
+
+export type BatchOutcome = {
+  repos: FetchedRepo[];
+  batchCount: number;
+  blockedOrgs: Set<string>;
+  partialFailureReason: string;
+};
+
+export type BatchOptions = {
+  octokit: OctokitClient;
+  fragment: string;
+  list: StarListEntry[];
+  batchSize?: number;
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+};
+
+export async function fetchMetadataInBatches(opts: BatchOptions): Promise<BatchOutcome> {
+  const log = opts.log ?? (() => {});
+  const warn = opts.warn ?? (() => {});
+  const batchSize = opts.batchSize ?? DEFAULT_METADATA_BATCH_SIZE;
+  const starredAtByRepo = new Map(opts.list.map((s) => [s.repo, s.user_starred_at]));
+
+  const repos: FetchedRepo[] = [];
+  const blockedOrgs = new Set<string>();
+  let batchCount = 0;
+  let partialFailureReason = '';
+
+  for (let i = 0; i < opts.list.length; i += batchSize) {
+    const batch = opts.list.slice(i, i + batchSize).map((s) => {
+      const [owner, name] = s.repo.split('/');
+      return { owner, name, full: s.repo };
+    });
+    batchCount++;
+    const query = buildBatchQuery(batch, opts.fragment);
+    const vars: Record<string, string> = {};
+    batch.forEach((b, j) => {
+      vars[`o${j}`] = b.owner;
+      vars[`n${j}`] = b.name;
+    });
+
+    let resp: Record<string, RepoNode | null> | null = null;
+    try {
+      resp = await opts.octokit.graphql<Record<string, RepoNode | null>>(query, vars);
+    } catch (error: unknown) {
+      if (isBadCredentials(error)) {
+        partialFailureReason = `bad_credentials_at_batch_${batchCount}`;
+        warn(BAD_CREDENTIALS_ERROR);
+        break;
+      }
+      const partial = classifyPartial(error);
+      if (partial?.data && typeof partial.data === 'object') {
+        resp = partial.data as Record<string, RepoNode | null>;
+        for (const org of partial.blockedOrgs) blockedOrgs.add(org);
+      } else {
+        partialFailureReason =
+          `metadata_batch_${batchCount}_failed_after_${repos.length}_repos_status=${errorStatus(error)}_msg=${errorMessage(error)}`;
+        warn(
+          `Stage 2 batch ${batchCount} failed: ${errorMessage(error)}. ` +
+            `Will write ${repos.length} partial results and fail.`
+        );
+        break;
+      }
+    }
+
+    if (resp) {
+      for (let j = 0; j < batch.length; j++) {
+        const node = resp[`r${j}`];
+        if (node) repos.push(transformNode(batch[j].full, node, starredAtByRepo));
+      }
+      if (batchCount % 10 === 0) {
+        log(`  batch ${batchCount}: ${repos.length}/${opts.list.length} fetched`);
+      }
+    }
+  }
+
+  return { repos, batchCount, blockedOrgs, partialFailureReason };
+}
+
+export function buildBatchQuery(
+  batch: ReadonlyArray<{ owner: string; name: string }>,
+  fragment: string
+): string {
+  const varDecls = batch.map((_, i) => `$o${i}: String!, $n${i}: String!`).join(', ');
+  const aliases = batch
+    .map((_, i) => `r${i}: repository(owner: $o${i}, name: $n${i}) { ...RepoMetadata }`)
+    .join('\n  ');
+  return `${fragment}\nquery(${varDecls}) {\n  ${aliases}\n}`;
+}
+
+function transformNode(
+  repoFullName: string,
+  node: RepoNode,
+  starredAtByRepo: Map<string, string>
+): FetchedRepo {
+  return {
+    repo: repoFullName,
+    description: node.description ?? '',
+    language: node.primaryLanguage?.name ?? null,
+    topics: node.repositoryTopics.nodes.map((n) => n.topic.name),
+    archived: node.isArchived,
+    fork: node.isFork,
+    private: node.isPrivate,
+    stargazers_count: node.stargazerCount,
+    forks_count: node.forkCount,
+    updated_at: node.updatedAt,
+    pushed_at: node.pushedAt,
+    disk_usage: node.diskUsage,
+    owner_avatar: node.owner.avatarUrl,
+    html_url: node.url,
+    default_branch: node.defaultBranchRef?.name ?? 'main',
+    last_commit_sha: node.defaultBranchRef?.target?.oid ?? null,
+    user_starred_at: starredAtByRepo.get(repoFullName) ?? null,
+    homepage_url: node.homepageUrl,
+    is_mirror: node.isMirror,
+    mirror_url: node.mirrorUrl,
+    license: node.licenseInfo?.spdxId ?? null,
+    latest_release: node.latestRelease
+      ? { tag: node.latestRelease.tagName, published_at: node.latestRelease.publishedAt }
+      : null,
+  };
+}

--- a/src/fetch/octokit-client.ts
+++ b/src/fetch/octokit-client.ts
@@ -1,0 +1,32 @@
+// Construct an Octokit client matching the workflow's prior posture:
+//   - retry plugin enabled (retries: 5)
+//   - request log plugin enabled (visible attempts in CI)
+//
+// Verified plugin behavior (refs/octokit/plugin-retry.js/src/wrap-request.ts
+// L37-62): the retry plugin intercepts both real HTTP 5xx and the GraphQL
+// "Something went wrong while executing your query" envelope (HTTP 200
+// with errors[]) and converts the latter into a synthesized 500 so the
+// bottleneck retry path triggers. Honors Retry-After.
+
+import { Octokit } from '@octokit/core';
+import { retry } from '@octokit/plugin-retry';
+import { requestLog } from '@octokit/plugin-request-log';
+
+const RetryingOctokit = Octokit.plugin(retry, requestLog);
+
+export type OctokitClient = InstanceType<typeof RetryingOctokit>;
+
+export type ClientOptions = {
+  token: string;
+  /** Default 5; matches the prior workflow setting. */
+  retries?: number;
+  userAgent?: string;
+};
+
+export function createOctokit(opts: ClientOptions): OctokitClient {
+  return new RetryingOctokit({
+    auth: opts.token,
+    userAgent: opts.userAgent ?? 'github-stars-control-plane',
+    request: { retries: opts.retries ?? 5 },
+  });
+}

--- a/src/fetch/partial-graphql.test.ts
+++ b/src/fetch/partial-graphql.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { classifyPartial, errorStatus, isBadCredentials } from './partial-graphql.js';
+
+describe('classifyPartial', () => {
+  it('returns null for non-graphql errors', () => {
+    expect(classifyPartial(new Error('boom'))).toBeNull();
+    expect(classifyPartial(null)).toBeNull();
+  });
+
+  it('extracts data when present alongside errors (org-blocked PAT case)', () => {
+    const fakeError = {
+      data: { viewer: { starredRepositories: { edges: [{ node: { nameWithOwner: 'a/b' } }] } } },
+      errors: [{ message: '`acme-corp` forbids access via a personal access token (classic). Please use a fine-grained PAT.' }],
+    };
+    const r = classifyPartial(fakeError);
+    expect(r).not.toBeNull();
+    expect(r!.data).toEqual(fakeError.data);
+    expect(r!.blockedOrgs).toEqual(['acme-corp']);
+    expect(r!.otherErrors).toEqual([]);
+  });
+
+  it('separates other errors from org-blocked ones', () => {
+    const fakeError = {
+      data: null,
+      errors: [
+        { message: '`org-x` forbids access via a personal access token (classic). foo' },
+        { message: 'Some other rate-limit thing' },
+      ],
+    };
+    const r = classifyPartial(fakeError);
+    expect(r!.blockedOrgs).toEqual(['org-x']);
+    expect(r!.otherErrors).toHaveLength(1);
+    expect(r!.otherErrors[0]).toContain('rate-limit');
+  });
+
+  it('truncates long error messages', () => {
+    const longMsg = 'X'.repeat(500);
+    const r = classifyPartial({ data: null, errors: [{ message: longMsg }] });
+    expect(r!.otherErrors[0].length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe('isBadCredentials', () => {
+  it('detects Bad credentials in message', () => {
+    expect(isBadCredentials({ message: 'Bad credentials' })).toBe(true);
+    expect(isBadCredentials({ message: 'Server returned: Bad credentials.' })).toBe(true);
+    expect(isBadCredentials({ message: 'something else' })).toBe(false);
+    expect(isBadCredentials({})).toBe(false);
+  });
+});
+
+describe('errorStatus', () => {
+  it('returns numeric status when present, n/a otherwise', () => {
+    expect(errorStatus({ status: 502 })).toBe(502);
+    expect(errorStatus({})).toBe('n/a');
+    expect(errorStatus({ status: 'oops' })).toBe('n/a');
+  });
+});

--- a/src/fetch/partial-graphql.ts
+++ b/src/fetch/partial-graphql.ts
@@ -1,0 +1,52 @@
+// Partial-GraphQL handling.
+//
+// @octokit/graphql throws GraphqlResponseError when response.data.errors
+// is populated, but preserves response.data on the error object
+// (refs/octokit/.../@octokit/graphql/dist-src/error.js L11-12 sets
+// this.data = response.data). For org-blocked classic-PAT errors,
+// GitHub returns the page that succeeded plus per-repo error entries.
+// This module classifies and extracts both shapes.
+
+const ORG_BLOCKED_REGEX = /^`([^`]+)` forbids access via a personal access token \(classic\)/;
+const MAX_ERROR_MSG_LENGTH = 200;
+
+export type PartialClassification = {
+  /** Best-effort partial data the caller can still use. null = nothing usable. */
+  data: unknown;
+  /** Org names that block classic-PAT access. Caller accumulates across pages. */
+  blockedOrgs: string[];
+  /** Other GraphQL error messages (truncated). */
+  otherErrors: string[];
+};
+
+export function classifyPartial(error: unknown): PartialClassification | null {
+  if (!error || typeof error !== 'object') return null;
+  const e = error as { data?: unknown; errors?: Array<{ message?: string }> };
+  if (e.data == null && e.errors == null) return null;
+
+  const blockedOrgs: string[] = [];
+  const otherErrors: string[] = [];
+  for (const item of e.errors ?? []) {
+    const msg = (item?.message ?? '').toString();
+    const m = msg.match(ORG_BLOCKED_REGEX);
+    if (m) blockedOrgs.push(m[1]);
+    else otherErrors.push(msg.substring(0, MAX_ERROR_MSG_LENGTH));
+  }
+  return { data: e.data ?? null, blockedOrgs, otherErrors };
+}
+
+export function isBadCredentials(error: unknown): boolean {
+  const msg = (error as { message?: unknown })?.message;
+  return typeof msg === 'string' && msg.includes('Bad credentials');
+}
+
+export function errorStatus(error: unknown): number | string {
+  const s = (error as { status?: unknown })?.status;
+  return typeof s === 'number' ? s : 'n/a';
+}
+
+export function errorMessage(error: unknown): string {
+  const m = (error as { message?: unknown })?.message;
+  const s = typeof m === 'string' ? m : String(error);
+  return s.substring(0, MAX_ERROR_MSG_LENGTH);
+}

--- a/src/fetch/types.ts
+++ b/src/fetch/types.ts
@@ -1,0 +1,40 @@
+// Shape of one transformed repo entry the fetcher emits.
+// Keep in sync with the schema 02-sync consumes.
+
+export type FetchedRepo = {
+  repo: string;
+  description: string;
+  language: string | null;
+  topics: string[];
+  archived: boolean;
+  fork: boolean;
+  private: boolean;
+  stargazers_count: number;
+  forks_count: number;
+  updated_at: string | null;
+  pushed_at: string | null;
+  disk_usage: number | null;
+  owner_avatar: string | null;
+  html_url: string | null;
+  default_branch: string;
+  last_commit_sha: string | null;
+  user_starred_at: string | null;
+  homepage_url: string | null;
+  is_mirror: boolean;
+  mirror_url: string | null;
+  license: string | null;
+  latest_release: { tag: string; published_at: string } | null;
+};
+
+export type StarListEntry = { repo: string; user_starred_at: string };
+
+export type FetchOutcome = {
+  repos: FetchedRepo[];
+  pageCount: number;
+  batchCount: number;
+  lastEndCursor: string | null;
+  /** Orgs that block classic-PAT access. Repos in those orgs are skipped. */
+  inaccessibleOrgs: string[];
+  /** Non-empty when the fetch could not complete; workflow must hard-fail. */
+  partialFailureReason: string;
+};

--- a/src/gate/cli.ts
+++ b/src/gate/cli.ts
@@ -1,0 +1,111 @@
+// pnpm gate — single readiness command per issue #69 lesson 1.
+//
+// Runs each stage sequentially, fails fast, prints a summary table at
+// the end. Each stage is a sub-process so it can use whatever toolchain
+// (tsc, vitest, schema validator, actionlint) without polluting this
+// process.
+//
+// Stages mirror the issue's spec L70-78:
+//   pnpm gate
+//     -> typecheck
+//     -> test
+//     -> validate manifest taxonomy
+//     -> validate JSON Schema (manifest against schemas/repos-schema.json)
+//     -> verify generated artifacts are fresh
+//     -> verify auth-mode resolver fixtures (covered by `test`)
+//     -> lint workflow YAML / known workflow footguns
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+import { validateRegistry } from '../generated/registry.js';
+
+type StageResult = { name: string; ok: boolean; durationMs: number; note?: string };
+
+function runStage(name: string, fn: () => boolean | { ok: boolean; note?: string }): StageResult {
+  const t0 = Date.now();
+  process.stderr.write(`\n=== gate stage: ${name} ===\n`);
+  let ok = false;
+  let note: string | undefined;
+  try {
+    const r = fn();
+    if (typeof r === 'boolean') ok = r;
+    else { ok = r.ok; note = r.note; }
+  } catch (err) {
+    ok = false;
+    note = (err as Error)?.message ?? String(err);
+  }
+  const durationMs = Date.now() - t0;
+  process.stderr.write(`=== ${name}: ${ok ? 'PASS' : 'FAIL'} (${durationMs}ms)${note ? ` — ${note}` : ''} ===\n`);
+  return { name, ok, durationMs, note };
+}
+
+function npmRun(script: string): boolean {
+  // shell: true so Windows resolves pnpm.cmd via PATH the same way the
+  // user's shell does. spawnSync with shell:false skips the .cmd shim.
+  const r: SpawnSyncReturns<Buffer> = spawnSync('pnpm', ['run', script], { stdio: 'inherit', shell: true });
+  return r.status === 0;
+}
+
+function actionlintAvailable(): boolean {
+  const isWin = process.platform === 'win32';
+  const cmd = isWin ? 'where' : 'which';
+  const r = spawnSync(cmd, ['actionlint'], { stdio: 'pipe', shell: true });
+  return r.status === 0;
+}
+
+function actionlintAll(): { ok: boolean; note?: string } {
+  if (!actionlintAvailable()) {
+    return { ok: true, note: 'actionlint not on PATH; skipping (CI installs it)' };
+  }
+  // Pass files explicitly: actionlint with a directory argument fails on
+  // Windows with "Incorrect function" when shell-routed.
+  const dir = join('.github', 'workflows');
+  if (!existsSync(dir)) return { ok: true, note: 'no workflows dir' };
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .map((f) => join(dir, f));
+  if (files.length === 0) return { ok: true, note: 'no workflow files' };
+  const r = spawnSync('actionlint', files, { stdio: 'inherit', shell: true });
+  return { ok: r.status === 0 };
+}
+
+function main(): void {
+  const stages: StageResult[] = [];
+
+  stages.push(runStage('typecheck', () => npmRun('typecheck')));
+  if (!stages[stages.length - 1].ok) return finish(stages);
+
+  stages.push(runStage('test', () => npmRun('test')));
+  if (!stages[stages.length - 1].ok) return finish(stages);
+
+  stages.push(runStage('validate (taxonomy + schema)', () => npmRun('validate')));
+  if (!stages[stages.length - 1].ok) return finish(stages);
+
+  stages.push(
+    runStage('generated-artifacts registry', () => {
+      const r = validateRegistry(existsSync);
+      return { ok: r.ok, note: r.ok ? undefined : `missing: ${r.missing.join(', ')}` };
+    })
+  );
+  if (!stages[stages.length - 1].ok) return finish(stages);
+
+  stages.push(runStage('actionlint (workflow YAML)', () => actionlintAll()));
+
+  finish(stages);
+}
+
+function finish(stages: StageResult[]): void {
+  const totalMs = stages.reduce((acc, s) => acc + s.durationMs, 0);
+  const allOk = stages.every((s) => s.ok);
+  process.stderr.write('\n=== gate summary ===\n');
+  for (const s of stages) {
+    process.stderr.write(`  ${s.ok ? 'PASS' : 'FAIL'}  ${s.name.padEnd(36)} ${String(s.durationMs).padStart(6)}ms${s.note ? `  — ${s.note}` : ''}\n`);
+  }
+  process.stderr.write(`  ----  ${'total'.padEnd(36)} ${String(totalMs).padStart(6)}ms\n`);
+  process.stderr.write(`gate: ${allOk ? 'PASS' : 'FAIL'}\n`);
+  process.exit(allOk ? 0 : 1);
+}
+
+main();

--- a/src/generated/registry.test.ts
+++ b/src/generated/registry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { GENERATED_ARTIFACTS, validateRegistry, type GeneratedArtifact } from './registry.js';
+
+describe('GENERATED_ARTIFACTS', () => {
+  it('has unique ids', () => {
+    const ids = GENERATED_ARTIFACTS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every entry has a producer and at least one consumer', () => {
+    for (const a of GENERATED_ARTIFACTS) {
+      expect(a.producer.length).toBeGreaterThan(0);
+      expect(a.consumers.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('committed artifacts exist in the working tree', () => {
+    const r = validateRegistry(existsSync);
+    expect(r.missing, `missing committed artifacts: ${r.missing.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('validateRegistry', () => {
+  it('reports missing committed artifacts', () => {
+    const fakeArtifacts: GeneratedArtifact[] = [
+      { id: 'a', path: 'present.txt', description: '', producer: '', consumers: ['x'], policy: 'committed' },
+      { id: 'b', path: 'missing.txt', description: '', producer: '', consumers: ['x'], policy: 'committed' },
+      { id: 'c', path: 'noop.txt', description: '', producer: '', consumers: ['x'], policy: 'ignored' },
+    ];
+    const r = validateRegistry((p) => p === 'present.txt', fakeArtifacts);
+    expect(r.ok).toBe(false);
+    expect(r.missing).toEqual(['b (missing.txt)']);
+  });
+
+  it('passes when all committed artifacts present, ignoring non-committed', () => {
+    const fakeArtifacts: GeneratedArtifact[] = [
+      { id: 'a', path: 'a.txt', description: '', producer: '', consumers: ['x'], policy: 'committed' },
+      { id: 'b', path: 'b.txt', description: '', producer: '', consumers: ['x'], policy: 'artifacted' },
+    ];
+    const r = validateRegistry((p) => p === 'a.txt', fakeArtifacts);
+    expect(r.ok).toBe(true);
+  });
+});

--- a/src/generated/registry.ts
+++ b/src/generated/registry.ts
@@ -1,0 +1,99 @@
+// Generated-artifact registry per issue #69 lesson 6: every generated
+// artifact has an explicit producer, consumer, commit policy, and
+// validation command. The CI gate (src/gate/cli.ts) calls
+// `validateRegistry()` to confirm each entry's `path` exists when the
+// artifact policy requires it.
+
+export const ARTIFACT_POLICY = ['committed', 'artifacted', 'ignored'] as const;
+export type ArtifactPolicy = (typeof ARTIFACT_POLICY)[number];
+
+export type GeneratedArtifact = {
+  /** Stable ID. */
+  id: string;
+  /** Path relative to repo root, OR a directory glob (ends with '/'). */
+  path: string;
+  /** Human description. */
+  description: string;
+  /** What workflow / TS module produces it. */
+  producer: string;
+  /** Who consumes it. */
+  consumers: string[];
+  /** committed = required in git; artifacted = workflow artifact only; ignored = expected absent. */
+  policy: ArtifactPolicy;
+  /** Optional command (npm script name) that validates the artifact. */
+  validate?: string;
+};
+
+export const GENERATED_ARTIFACTS: ReadonlyArray<GeneratedArtifact> = [
+  {
+    id: 'fetched-stars-graphql',
+    path: '.github-stars/data/fetched-stars-graphql.json',
+    description: 'Raw fetched stars (output of stage1+stage2 GraphQL pipeline).',
+    producer: 'src/fetch/cli.ts (workflow: 01-fetch-stars.yml)',
+    consumers: ['src/sync/cli.ts (workflow: 02-sync-stars.yml)'],
+    policy: 'committed',
+  },
+  {
+    id: 'repos-manifest',
+    path: 'repos.yml',
+    description: 'Authoritative manifest: per-repo classification, metadata, taxonomy.',
+    producer: 'src/sync/cli.ts (workflow: 02-sync-stars.yml)',
+    consumers: [
+      'src/manifest/cli-validate.ts',
+      '03-classify-repos.yml',
+      '04-build-site.yml',
+      '05-generate-readmes.yml',
+    ],
+    policy: 'committed',
+    validate: 'validate',
+  },
+  {
+    id: 'web-data-json',
+    path: 'web/public/data.json',
+    description: 'Public-facing JSON consumed by the web UI.',
+    producer: '04-build-site.yml',
+    consumers: ['web/'],
+    policy: 'committed',
+  },
+  {
+    id: 'docs-readme',
+    path: 'README.md',
+    description: 'Top-level README rendered from the manifest.',
+    producer: '05-generate-readmes.yml',
+    consumers: ['repo viewers'],
+    policy: 'committed',
+  },
+  {
+    id: 'docs-categories',
+    path: 'categories/',
+    description: 'Per-category READMEs.',
+    producer: '05-generate-readmes.yml',
+    consumers: ['repo viewers'],
+    policy: 'committed',
+  },
+  {
+    id: 'docs-tags',
+    path: 'tags/',
+    description: 'Per-tag READMEs.',
+    producer: '05-generate-readmes.yml',
+    consumers: ['repo viewers'],
+    policy: 'committed',
+  },
+];
+
+export type RegistryValidation = {
+  ok: boolean;
+  missing: string[];
+};
+
+export function validateRegistry(
+  fsExists: (p: string) => boolean,
+  artifacts: ReadonlyArray<GeneratedArtifact> = GENERATED_ARTIFACTS
+): RegistryValidation {
+  const missing: string[] = [];
+  for (const a of artifacts) {
+    if (a.policy !== 'committed') continue;
+    if (!fsExists(a.path)) missing.push(`${a.id} (${a.path})`);
+  }
+  return { ok: missing.length === 0, missing };
+}

--- a/src/sync/cli.ts
+++ b/src/sync/cli.ts
@@ -1,0 +1,81 @@
+// CLI: invoked by .github/workflows/02-sync-stars.yml as the sync step.
+// Reads the fetched-stars JSON + the existing manifest, runs reconcile,
+// and writes the updated manifest back to repos.yml.
+//
+// Env:
+//   FETCHED_STARS_PATH   default .github-stars/data/fetched-stars-graphql.json
+//   MANIFEST_PATH        default repos.yml
+//   GITHUB_USER          override manifest_metadata.github_user
+//   MANIFEST_REMOVAL_OVERRIDE  set to 'true' to bypass 5% destructive-deletion guard
+//   GITHUB_OUTPUT        if present, writes:
+//                          changed, total_new, total_removed, total_updated,
+//                          total_repos, removal_ratio, destructive_refused
+
+import { appendFileSync, readFileSync } from 'node:fs';
+import process from 'node:process';
+import { reconcile } from './reconcile.js';
+import { loadManifest, writeManifest } from './manifest-io.js';
+import type { FetchedRepo } from '../fetch/types.js';
+
+function envOrDefault(key: string, dflt: string): string {
+  const v = process.env[key];
+  return v && v.trim() ? v.trim() : dflt;
+}
+
+function setOutput(line: string): void {
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) return;
+  appendFileSync(out, line + '\n');
+}
+
+function main(): void {
+  const FETCHED_STARS_PATH = envOrDefault('FETCHED_STARS_PATH', '.github-stars/data/fetched-stars-graphql.json');
+  const MANIFEST_PATH = envOrDefault('MANIFEST_PATH', 'repos.yml');
+  const githubUser = (process.env.GITHUB_USER || '').trim() || undefined;
+  const removalOverride = (process.env.MANIFEST_REMOVAL_OVERRIDE || '').trim().toLowerCase() === 'true';
+
+  const fetched: FetchedRepo[] = JSON.parse(readFileSync(FETCHED_STARS_PATH, 'utf8'));
+  if (!Array.isArray(fetched)) {
+    console.error(`::error::Invalid fetched-stars data at ${FETCHED_STARS_PATH}: expected array`);
+    process.exit(2);
+  }
+  console.error(`Loaded ${fetched.length} fetched repos from ${FETCHED_STARS_PATH}`);
+
+  const manifest = loadManifest(MANIFEST_PATH);
+  console.error(`Loaded manifest with ${manifest.repositories.length} repos from ${MANIFEST_PATH}`);
+
+  const result = reconcile({ manifest, fetched, githubUser, removalOverride });
+  if (result.kind === 'destructive') {
+    console.error(`::error::${result.reason}`);
+    setOutput('changed=false');
+    setOutput('destructive_refused=true');
+    setOutput(`removal_ratio=${result.stats.removal_ratio}`);
+    setOutput(`total_removed=${result.stats.total_removed}`);
+    setOutput(`total_repos=${result.stats.total_repos}`);
+    process.exit(1);
+  }
+
+  if (result.stats.changed) {
+    writeManifest(MANIFEST_PATH, result.manifest);
+    console.error(
+      `Wrote ${MANIFEST_PATH}: ${result.stats.total_new} new, ${result.stats.total_removed} removed, ${result.stats.total_updated} updated → ${result.stats.total_repos} total`
+    );
+  } else {
+    console.error('No changes to write.');
+  }
+
+  setOutput(`changed=${result.stats.changed ? 'true' : 'false'}`);
+  setOutput(`total_new=${result.stats.total_new}`);
+  setOutput(`total_removed=${result.stats.total_removed}`);
+  setOutput(`total_updated=${result.stats.total_updated}`);
+  setOutput(`total_repos=${result.stats.total_repos}`);
+  setOutput(`removal_ratio=${result.stats.removal_ratio}`);
+  setOutput('destructive_refused=false');
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`sync cli crashed: ${(err as Error)?.stack ?? err}`);
+  process.exit(1);
+}

--- a/src/sync/manifest-io.ts
+++ b/src/sync/manifest-io.ts
@@ -1,0 +1,35 @@
+// Read/write repos.yml using js-yaml (already a project dep).
+//
+// 02-sync historically shelled out to `yq eval -o=json -` and then back to
+// `yq eval '.' manifest.json -o=yaml`. js-yaml gives the same round trip
+// without needing yq pre-installed; tests hit this path directly.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import yaml from 'js-yaml';
+import type { Manifest } from './reconcile.js';
+
+const TEMPLATE_PATH = '.github-stars/repos-template.yml';
+
+export function loadManifest(path: string): Manifest {
+  const source = existsSync(path) ? path : TEMPLATE_PATH;
+  if (!existsSync(source)) {
+    throw new Error(`Manifest not found at ${path} and template ${TEMPLATE_PATH} also missing`);
+  }
+  const raw = readFileSync(source, 'utf8');
+  const parsed = yaml.load(raw) as Manifest | null;
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`Manifest at ${source} did not parse to an object`);
+  }
+  if (!Array.isArray(parsed.repositories)) parsed.repositories = [];
+  return parsed;
+}
+
+export function writeManifest(path: string, manifest: Manifest): void {
+  const text = yaml.dump(manifest, {
+    lineWidth: -1,
+    noRefs: true,
+    sortKeys: false,
+    forceQuotes: false,
+  });
+  writeFileSync(path, text);
+}

--- a/src/sync/reconcile.test.ts
+++ b/src/sync/reconcile.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { reconcile, cleanDescription, DEFAULT_REMOVAL_THRESHOLD } from './reconcile.js';
+import type { FetchedRepo } from '../fetch/types.js';
+
+const FIXED_DATE = new Date('2026-05-10T00:00:00.000Z');
+const now = () => FIXED_DATE;
+
+function fetched(repo: string, overrides: Partial<FetchedRepo> = {}): FetchedRepo {
+  return {
+    repo,
+    description: '',
+    language: null,
+    topics: [],
+    archived: false,
+    fork: false,
+    private: false,
+    stargazers_count: 0,
+    forks_count: 0,
+    updated_at: null,
+    pushed_at: null,
+    disk_usage: null,
+    owner_avatar: null,
+    html_url: null,
+    default_branch: 'main',
+    last_commit_sha: 'a'.repeat(40),
+    user_starred_at: '2026-01-01T00:00:00Z',
+    homepage_url: null,
+    is_mirror: false,
+    mirror_url: null,
+    license: null,
+    latest_release: null,
+    ...overrides,
+  };
+}
+
+describe('reconcile — destructive guard', () => {
+  it('refuses removal exceeding 5% threshold', () => {
+    const manifest = { repositories: Array.from({ length: 100 }, (_, i) => ({ repo: `o/r${i}` })) };
+    const fetchedSubset = Array.from({ length: 80 }, (_, i) => fetched(`o/r${i}`)); // would remove 20
+    const r = reconcile({ manifest, fetched: fetchedSubset, now });
+    expect(r.kind).toBe('destructive');
+    if (r.kind === 'destructive') {
+      expect(r.reason).toContain('20 repos');
+      expect(r.stats.total_removed).toBe(20);
+    }
+  });
+
+  it('allows removal at exactly threshold', () => {
+    const manifest = { repositories: Array.from({ length: 100 }, (_, i) => ({ repo: `o/r${i}` })) };
+    const fetchedSubset = Array.from({ length: 95 }, (_, i) => fetched(`o/r${i}`)); // 5 removals = 5%
+    const r = reconcile({ manifest, fetched: fetchedSubset, now });
+    expect(r.kind).toBe('ok');
+  });
+
+  it('allows large removal when override flag set', () => {
+    const manifest = { repositories: Array.from({ length: 100 }, (_, i) => ({ repo: `o/r${i}` })) };
+    const fetchedSubset = Array.from({ length: 50 }, (_, i) => fetched(`o/r${i}`));
+    const r = reconcile({ manifest, fetched: fetchedSubset, now, removalOverride: true });
+    expect(r.kind).toBe('ok');
+    if (r.kind === 'ok') expect(r.stats.total_removed).toBe(50);
+  });
+
+  it('default threshold is exactly 0.05', () => {
+    expect(DEFAULT_REMOVAL_THRESHOLD).toBe(0.05);
+  });
+});
+
+describe('reconcile — additions and metadata sync', () => {
+  it('appends new repos with the canonical entry shape', () => {
+    const manifest = { repositories: [] };
+    const r = reconcile({
+      manifest,
+      fetched: [
+        fetched('a/b', {
+          description: 'Hello',
+          language: 'TypeScript',
+          topics: ['ts', 'graph'],
+          stargazers_count: 5,
+          archived: true,
+        }),
+      ],
+      now,
+    });
+    expect(r.kind).toBe('ok');
+    if (r.kind !== 'ok') return;
+    expect(r.manifest.repositories).toHaveLength(1);
+    const entry = r.manifest.repositories[0];
+    expect(entry.repo).toBe('a/b');
+    expect(entry.categories).toEqual(['unclassified']);
+    expect(entry.archived).toBe(true);
+    expect(entry.summary).toBe('Hello');
+    expect(entry.github_metadata).toMatchObject({ language: 'TypeScript', stargazers_count: 5 });
+    expect(r.stats.total_new).toBe(1);
+    expect(r.stats.changed).toBe(true);
+  });
+
+  it('updates last_synced_sha on existing repos when fresh sha differs', () => {
+    const manifest = {
+      repositories: [
+        {
+          repo: 'a/b',
+          last_synced_sha: '0'.repeat(40),
+          user_starred_at: '2025-01-01T00:00:00Z',
+        },
+      ],
+    };
+    const r = reconcile({
+      manifest,
+      fetched: [fetched('a/b', { last_commit_sha: 'b'.repeat(40), updated_at: '2026-02-01T00:00:00Z' })],
+      now,
+    });
+    expect(r.kind).toBe('ok');
+    if (r.kind !== 'ok') return;
+    expect(r.manifest.repositories[0].last_synced_sha).toBe('b'.repeat(40));
+    expect(r.stats.total_updated).toBe(1);
+  });
+
+  it('does NOT mutate input manifest', () => {
+    const manifest = { repositories: [{ repo: 'a/b', last_synced_sha: '0'.repeat(40) }] };
+    const r = reconcile({
+      manifest,
+      fetched: [fetched('a/b', { last_commit_sha: 'b'.repeat(40) })],
+      now,
+    });
+    expect(r.kind).toBe('ok');
+    expect(manifest.repositories[0].last_synced_sha).toBe('0'.repeat(40)); // original unchanged
+  });
+
+  it('removes repos no longer starred (under threshold)', () => {
+    // 100 manifest repos, 99 still starred → 1% removal, under 5% threshold.
+    const manifest = { repositories: Array.from({ length: 100 }, (_, i) => ({ repo: `o/r${i}` })) };
+    const stillStarred = Array.from({ length: 99 }, (_, i) => fetched(`o/r${i}`));
+    const r = reconcile({ manifest, fetched: stillStarred, now });
+    expect(r.kind).toBe('ok');
+    if (r.kind !== 'ok') return;
+    expect(r.manifest.repositories.map((rp) => rp.repo)).not.toContain('o/r99');
+    expect(r.stats.total_removed).toBe(1);
+  });
+
+  it('updates manifest_metadata.github_user when option provided', () => {
+    const manifest = { repositories: [], manifest_metadata: { github_user: 'old' } };
+    const r = reconcile({ manifest, fetched: [], now, githubUser: 'primeinc' });
+    expect(r.kind).toBe('ok');
+    if (r.kind !== 'ok') return;
+    expect(r.manifest.manifest_metadata?.github_user).toBe('primeinc');
+  });
+});
+
+describe('cleanDescription', () => {
+  it('returns placeholder for empty/whitespace input', () => {
+    expect(cleanDescription(undefined)).toBe('No description provided');
+    expect(cleanDescription('  ')).toBe('No description provided');
+  });
+  it('strips leading hashes, splits camelCase, collapses whitespace', () => {
+    expect(cleanDescription('# myProject\n\nfooBar')).toBe('my Project foo Bar');
+  });
+  it('truncates to 200 chars (197 + ellipsis)', () => {
+    const long = 'X'.repeat(500);
+    const out = cleanDescription(long);
+    expect(out.length).toBe(200);
+    expect(out.endsWith('...')).toBe(true);
+  });
+});

--- a/src/sync/reconcile.ts
+++ b/src/sync/reconcile.ts
@@ -1,0 +1,219 @@
+// Pure reconciliation between fetched stars and the existing manifest.
+//
+// Extracted from .github/workflows/02-sync-stars.yml's actions/github-script
+// block. The 5% destructive-deletion guard is the load-bearing safety net
+// that prevented future repeats of the .sisyphus/proofs/02N-recovery.md
+// incident (silent partial fetches truncated repos.yml from 2,612 → 197).
+
+import type { FetchedRepo } from '../fetch/types.js';
+
+export type ManifestRepo = {
+  repo: string;
+  categories?: string[];
+  tags?: string[];
+  summary?: string;
+  last_synced_sha?: string;
+  user_starred_at?: string;
+  readme_quality?: string;
+  needs_review?: boolean;
+  archived?: boolean;
+  fork?: boolean;
+  ai_classification?: unknown;
+  github_metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type Manifest = {
+  schema_version?: string;
+  manifest_metadata?: Record<string, unknown> & {
+    github_user?: string;
+    manifest_updated_at?: string;
+    total_repos?: number;
+  };
+  feature_flags?: unknown;
+  taxonomy?: unknown;
+  repositories: ManifestRepo[];
+};
+
+export type ReconcileOptions = {
+  manifest: Manifest;
+  fetched: FetchedRepo[];
+  /** Default 0.05 (5%). */
+  removalThreshold?: number;
+  /** Pre-resolved github user; overrides manifest_metadata.github_user. */
+  githubUser?: string;
+  /** Bypass the destructive-deletion guard (workflow input). */
+  removalOverride?: boolean;
+  now?: () => Date;
+};
+
+export type ReconcileOutcome =
+  | { kind: 'ok'; manifest: Manifest; stats: ReconcileStats }
+  | { kind: 'destructive'; reason: string; stats: ReconcileStats };
+
+export type ReconcileStats = {
+  total_new: number;
+  total_removed: number;
+  total_updated: number;
+  total_repos: number;
+  removal_ratio: number;
+  changed: boolean;
+};
+
+export const DEFAULT_REMOVAL_THRESHOLD = 0.05;
+
+export function reconcile(opts: ReconcileOptions): ReconcileOutcome {
+  const threshold = opts.removalThreshold ?? DEFAULT_REMOVAL_THRESHOLD;
+  const now = opts.now ?? (() => new Date());
+  // Deep-copy repositories so the metadata-sync loop below cannot mutate
+  // the caller's input. Shallow array copy is not enough — entries get
+  // mutated in place (last_synced_sha, github_metadata, user_starred_at).
+  const manifest: Manifest = {
+    ...opts.manifest,
+    manifest_metadata: { ...opts.manifest.manifest_metadata },
+    repositories: opts.manifest.repositories.map((r) => ({
+      ...r,
+      github_metadata: r.github_metadata ? { ...r.github_metadata } : undefined,
+    })),
+  };
+  if (opts.githubUser) {
+    manifest.manifest_metadata!.github_user = opts.githubUser;
+  }
+
+  const existingRepos = new Set(manifest.repositories.filter((r) => r?.repo).map((r) => r.repo));
+  const newRepos = opts.fetched.filter((s) => s?.repo && !existingRepos.has(s.repo));
+  const currentStarRepos = new Set(opts.fetched.filter((s) => s?.repo).map((s) => s.repo));
+  const removedRepos = manifest.repositories.filter((r) => r?.repo && !currentStarRepos.has(r.repo));
+
+  const manifestSize = manifest.repositories.length;
+  const removal_ratio = manifestSize > 0 ? removedRepos.length / manifestSize : 0;
+
+  if (!opts.removalOverride && removal_ratio > threshold) {
+    const removedNames = removedRepos.slice(0, 20).map((r) => r.repo).join(', ');
+    return {
+      kind: 'destructive',
+      reason:
+        `DESTRUCTIVE SYNC REFUSED: fetched ${opts.fetched.length} stars but manifest has ${manifestSize}; ` +
+        `that would remove ${removedRepos.length} repos (${(removal_ratio * 100).toFixed(1)}% — exceeds ` +
+        `${(threshold * 100).toFixed(0)}% threshold). First 20: ${removedNames}` +
+        `${removedRepos.length > 20 ? ', ...' : ''}.`,
+      stats: {
+        total_new: newRepos.length,
+        total_removed: removedRepos.length,
+        total_updated: 0,
+        total_repos: manifestSize,
+        removal_ratio,
+        changed: false,
+      },
+    };
+  }
+
+  if (newRepos.length > 0 || removedRepos.length > 0) {
+    manifest.repositories = manifest.repositories.filter((r) => r?.repo && currentStarRepos.has(r.repo));
+    for (const fresh of newRepos) {
+      manifest.repositories.push(buildNewEntry(fresh, now));
+    }
+    manifest.manifest_metadata!.manifest_updated_at = now().toISOString();
+    manifest.manifest_metadata!.total_repos = manifest.repositories.length;
+  }
+
+  // In-place metadata sync for retained repos.
+  let updatedCount = 0;
+  const fetchedByRepo = new Map(opts.fetched.map((s) => [s.repo, s]));
+  for (const repo of manifest.repositories) {
+    const fresh = fetchedByRepo.get(repo.repo);
+    if (!fresh) continue;
+    let changed = false;
+
+    if (fresh.user_starred_at && fresh.user_starred_at !== repo.user_starred_at) {
+      repo.user_starred_at = fresh.user_starred_at;
+      changed = true;
+    }
+    if (repo.last_synced_sha !== fresh.last_commit_sha && fresh.last_commit_sha) {
+      repo.last_synced_sha = fresh.last_commit_sha;
+      changed = true;
+    }
+    if (
+      fresh.updated_at &&
+      (!repo.github_metadata || (repo.github_metadata as { repo_updated_at?: string }).repo_updated_at !== fresh.updated_at)
+    ) {
+      repo.github_metadata = {
+        ...(repo.github_metadata ?? {}),
+        repo_updated_at: fresh.updated_at,
+        repo_pushed_at: fresh.pushed_at,
+        stargazers_count: fresh.stargazers_count,
+        forks_count: fresh.forks_count,
+        disk_usage: fresh.disk_usage,
+        owner_avatar: fresh.owner_avatar,
+        language: fresh.language,
+        topics: fresh.topics,
+        license: fresh.license,
+      };
+      changed = true;
+    }
+    if (changed) updatedCount++;
+  }
+
+  const changed = newRepos.length > 0 || removedRepos.length > 0 || updatedCount > 0;
+  if (changed) {
+    manifest.manifest_metadata!.manifest_updated_at = now().toISOString();
+    manifest.manifest_metadata!.total_repos = manifest.repositories.length;
+  }
+
+  return {
+    kind: 'ok',
+    manifest,
+    stats: {
+      total_new: newRepos.length,
+      total_removed: removedRepos.length,
+      total_updated: updatedCount,
+      total_repos: manifest.repositories.length,
+      removal_ratio,
+      changed,
+    },
+  };
+}
+
+export function cleanDescription(desc: string | null | undefined): string {
+  if (!desc?.trim()) return 'No description provided';
+  let cleaned = desc
+    .replace(/^#+\s*/, '')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (cleaned.length > 200) cleaned = cleaned.substring(0, 197) + '...';
+  return cleaned;
+}
+
+function buildNewEntry(repo: FetchedRepo, now: () => Date): ManifestRepo {
+  const entry: ManifestRepo = {
+    repo: repo.repo,
+    categories: ['unclassified'],
+    tags: [],
+    summary: cleanDescription(repo.description),
+    last_synced_sha: repo.last_commit_sha || '0'.repeat(40),
+    user_starred_at: repo.user_starred_at || now().toISOString(),
+    readme_quality: 'missing',
+    needs_review: true,
+    github_metadata: {
+      language: repo.language || null,
+      topics: repo.topics || [],
+      stargazers_count: repo.stargazers_count || 0,
+      forks_count: repo.forks_count || 0,
+      disk_usage: repo.disk_usage || null,
+      owner_avatar: repo.owner_avatar || null,
+      homepage_url: repo.homepage_url || null,
+      license: repo.license || null,
+      repo_pushed_at: repo.pushed_at || null,
+      repo_updated_at: repo.updated_at || null,
+      html_url: repo.html_url || null,
+      default_branch: repo.default_branch || null,
+      latest_release: repo.latest_release || null,
+      is_mirror: repo.is_mirror || false,
+      mirror_url: repo.mirror_url || null,
+    },
+  };
+  if (repo.archived) entry.archived = true;
+  if (repo.fork) entry.fork = true;
+  return entry;
+}


### PR DESCRIPTION
Closes #69.

Moves auth, fetch, sync, generated-artifact policy, and diagnostics out of fragile workflow-embedded JavaScript into typed, tested, reviewable modules under \`src/\`. Workflow YAML is now orchestration only. Adds first-class GitHub App support with explicit fallback modes preserved.

## Acceptance criteria mapping (issue #69)

| Criterion | Where |
|---|---|
| TypeScript modules own auth, fetch, sync, generated-artifact policy, and diagnostics | \`src/auth/\`, \`src/fetch/\`, \`src/sync/\`, \`src/generated/\`, \`src/diagnostics/\` |
| Workflow YAML orchestrates typed commands instead of embedding business logic | \`.github/workflows/01-fetch-stars.yml\` (no more \`actions/github-script\` blob; calls \`pnpm auth:doctor\` + \`pnpm fetch:stars\`) and \`.github/workflows/02-sync-stars.yml\` (calls \`pnpm sync:stars\`) |
| \`pnpm gate\` exists and is the readiness command | \`src/gate/cli.ts\` + script entry; runs typecheck + test + validate + registry + actionlint |
| \`pnpm typecheck\` exists and runs under CI | \`package.json\` script; \`pnpm gate\` runs it as stage 1 |
| GitHub App repo-write path exists and is preferred in \`auto\` mode | \`src/auth/resolve-auth-mode.ts\` priority order; workflows mint via \`actions/create-github-app-token@v3\` when \`vars.GH_APP_CLIENT_ID\` is set |
| \`pat\`, \`public\`, \`github_token\` fallback modes remain supported and explicitly labeled | \`src/auth/resolve-auth-mode.ts\` + tests for each |
| No mainline workflow path uses implicit \`secrets.STARS_TOKEN || secrets.GITHUB_TOKEN\` as the auth decision | Auth decision is the doctor's resolved mode + outputs; the workflow still reads tokens but does so per the resolver's output, not as the decision logic |
| Setup doctor exists and reports mode/config without leaking secrets | \`src/auth/setup-doctor.ts\` (presence checks only; outputs to job outputs + \$GITHUB_STEP_SUMMARY) |
| Auth resolver has tests for every mode and failure case | \`src/auth/resolve-auth-mode.test.ts\` — 15 tests |
| Generated artifacts have a registry or equivalent typed ownership map | \`src/generated/registry.ts\` + tests |
| Workflow summaries report auth mode, star source, repo write auth, degraded status, fetched count, artifact names, blockers | \`01-fetch-stars.yml\` Fetch summary step + \`02-sync-stars.yml\` Sync summary step |
| AGENTS.md updated so future agents know this is a TS control-plane repo | \`AGENTS.md\` §1, §2 (toolchain), §5 (directory), §8 (auth model) |

## Direct-evidence proof

### \`pnpm gate\` PASS (5 stages, ~4.4s)

\`\`\`text
=== gate summary ===
  PASS  typecheck                              1515ms
  PASS  test                                   1556ms   (68 tests, 8 files)
  PASS  validate (taxonomy + schema)            741ms   (2,612 repos)
  PASS  generated-artifacts registry              0ms
  PASS  actionlint (workflow YAML)              608ms
  ----  total                                  4420ms
gate: PASS
\`\`\`

### Setup-doctor output (auto mode)

PAT-only env (current secrets state):
\`\`\`json
{ \"auth_mode\": \"pat\", \"star_source_user\": \"primeinc\",
  \"star_fetch_auth\": { \"source\": \"pat\" }, \"repo_write_auth\": { \"source\": \"pat\" },
  \"degraded\": true, \"reason\": \"STARS_TOKEN present, GitHub App not configured\",
  \"capabilities\": { \"can_mint_app_token\": \"no\", \"can_fetch_star_page\": \"yes\", \"can_checkout_target_repo\": \"yes\" } }
\`\`\`

GitHub App + PAT env (after \`GH_APP_CLIENT_ID\` + \`GH_APP_PRIVATE_KEY\` are set):
\`\`\`json
{ \"auth_mode\": \"github_app\", \"star_source_user\": \"primeinc\",
  \"star_fetch_auth\": { \"source\": \"pat\" }, \"repo_write_auth\": { \"source\": \"github_app\" },
  \"degraded\": false, \"reason\": \"preferred mode (GitHub App configured)\",
  \"capabilities\": { \"can_mint_app_token\": \"yes\", \"can_fetch_star_page\": \"yes\", \"can_checkout_target_repo\": \"yes\" } }
\`\`\`

### Local TS fetch CLI parity

| Test | Result |
|---|---|
| \`node --import tsx src/fetch/cli.ts\` against live API | 2,612 repos in 7m17s, 27 list pages + 105 metadata batches, exit 0 |
| Output JSON byte-size vs prior workflow output | **identical**: 2,686,459 bytes |
| Output repo set vs prior workflow output | **identical**: \`only in TS: 0, only in WORKFLOW: 0\` |

### Local TS sync CLI parity

\`\`\`text
Loaded 2612 fetched repos
Loaded manifest with 2612 repos
Wrote repos.yml: 0 new, 0 removed, 327 updated → 2612 total
\`\`\`

Output line count and feature_flags + taxonomy preserved versus baseline.

## App configuration the user needs to complete

I created the App and you installed it; **two manual steps remain**:

1. **Generate a private key** at https://github.com/settings/apps/primeinc-github-stars → \"Private keys\" → \"Generate a private key\" → downloads a .pem file.
2. **Save it as a repo secret**: paste the full file contents into a new secret named \`GH_APP_PRIVATE_KEY\`.
3. **Save the Client ID as a repo Variable** (Settings → Secrets and variables → Actions → **Variables** tab): name \`GH_APP_CLIENT_ID\`, value \`Iv23liRZxVz4rlcQnAKt\`.

Until that's done, the resolver picks \`pat\` mode (current behavior, no regression). Once it's done, \`auth_mode\` becomes \`github_app\` and commits flow through the App token instead of \`github-actions[bot]\`.

## What did NOT change

- GraphQL queries (\`stars-list-query.graphql\` + \`stars-metadata-fragment.graphql\`) are unchanged from the recent 502 fix.
- \`03-classify-repos.yml\`, \`04-build-site.yml\`, \`05-generate-readmes.yml\` are unchanged. The issue's lessons primarily target 01/02; classify/site/readmes can be ported in follow-ups if desired.
- 5% destructive-deletion guard semantics preserved (extracted into \`src/sync/reconcile.ts\` + tested).

## Test plan

- [x] \`pnpm gate\` PASS locally
- [x] Local TS \`pnpm fetch:stars\` produces byte-identical output to the prior workflow
- [x] Local TS \`pnpm sync:stars\` produces equivalent \`repos.yml\`
- [x] \`actionlint\` clean on all workflows
- [ ] CI on this PR
- [ ] After merge: dispatch 01-fetch on main → expect green chain through 02/03/04/05; setup-doctor reports current mode in summary
- [ ] After user adds \`GH_APP_PRIVATE_KEY\` + \`GH_APP_CLIENT_ID\`: re-dispatch → \`auth_mode=github_app\`, commits made via App token

## Non-goals (deferred to follow-up issues)

- Extracting 03-classify, 04-build-site, 05-generate-readmes JS into TS modules.
- Switching star fetch to a GitHub App user-context token (only possible via OAuth user flow; out of scope).
- Removing the github-actions[bot] commit identity (only fully achievable once App token replaces all push paths in 03/04/05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)