### PR TITLE
auth: strict 3-mode resolver + App-mode REST fetch (kills credential mixing)

### DIFF
--- a/.github/workflows/00-ci.yml
+++ b/.github/workflows/00-ci.yml
@@ -144,12 +144,17 @@ jobs:
           shopt -s nullglob
           files=( .github/workflows/*.yml .github/workflows/*.yaml )
           bad=""
+          # Strip comment lines (lines whose first non-whitespace char is #)
+          # before grepping. Without this the guard would self-trip on its
+          # own diagnostic comments — same class of bug as the
+          # cardinalby-mode guard hit in v1 (see 02M-mode-correction.md).
           for f in "${files[@]}"; do
+            non_comments=$(grep -vE '^[[:space:]]*#' "$f" || true)
             # Pattern 1: STARS_TOKEN || GITHUB_TOKEN (any order, any whitespace).
-            hit1=$(grep -nE 'secrets\.STARS_TOKEN[[:space:]]*\|\|[[:space:]]*secrets\.GITHUB_TOKEN' "$f" || true)
-            hit2=$(grep -nE 'secrets\.GITHUB_TOKEN[[:space:]]*\|\|[[:space:]]*secrets\.STARS_TOKEN' "$f" || true)
+            hit1=$(printf '%s\n' "$non_comments" | grep -nE 'secrets\.STARS_TOKEN[[:space:]]*\|\|[[:space:]]*secrets\.GITHUB_TOKEN' || true)
+            hit2=$(printf '%s\n' "$non_comments" | grep -nE 'secrets\.GITHUB_TOKEN[[:space:]]*\|\|[[:space:]]*secrets\.STARS_TOKEN' || true)
             # Pattern 2: app-token.outputs.token OR'd with any other secret.
-            hit3=$(grep -nE 'app-token\.outputs\.token[[:space:]]*\|\|[[:space:]]*secrets\.' "$f" || true)
+            hit3=$(printf '%s\n' "$non_comments" | grep -nE 'app-token\.outputs\.token[[:space:]]*\|\|[[:space:]]*secrets\.' || true)
             for h in "$hit1" "$hit2" "$hit3"; do
               if [ -n "$h" ]; then bad="${bad}${f}:\n${h}\n"; fi
             done
@@ -175,12 +180,16 @@ jobs:
           shopt -s nullglob
           files=( .github/workflows/*.yml .github/workflows/*.yaml )
           bad=""
+          # Strip comment lines first so the guard cannot self-trip on
+          # its own inline doc text. Same defensive pattern as the
+          # mixed-credential guard above.
           for f in "${files[@]}"; do
-            # ^\s*blocked_orgs: ... (job/step output key, not _count).
-            hit=$(grep -nE "^[[:space:]]+blocked_orgs:[[:space:]]" "$f" || true)
+            non_comments=$(grep -vE '^[[:space:]]*#' "$f" || true)
+            # ^\s+blocked_orgs: ... (job/step output key, not _count).
+            hit=$(printf '%s\n' "$non_comments" | grep -nE "^[[:space:]]+blocked_orgs:[[:space:]]" || true)
             if [ -n "$hit" ]; then bad="${bad}${f}:\n${hit}\n"; fi
             # BLOCKED_ORGS env var (used to substitute names into summaries).
-            hit2=$(grep -nE "^[[:space:]]+BLOCKED_ORGS:[[:space:]]" "$f" || true)
+            hit2=$(printf '%s\n' "$non_comments" | grep -nE "^[[:space:]]+BLOCKED_ORGS:[[:space:]]" || true)
             if [ -n "$hit2" ]; then bad="${bad}${f}:\n${hit2}\n"; fi
           done
           if [ -n "$bad" ]; then

--- a/.github/workflows/00-ci.yml
+++ b/.github/workflows/00-ci.yml
@@ -129,6 +129,69 @@ jobs:
           fi
           echo "No invalid mode values found in cardinalby/schema-validator-action steps."
 
+      # Per session-oracle verdict rule 1-7: a workflow MUST NOT silently
+      # mix credential classes. The historical laundering shape was
+      #   `secrets.STARS_TOKEN || secrets.GITHUB_TOKEN`
+      # or
+      #   `steps.app-token.outputs.token || secrets.STARS_TOKEN || ...`
+      # Reject any expression that ORs across credential classes inside
+      # a single role (token slot). Allowed: branch on
+      # steps.doctor.outputs.selected_mode and assign one credential per
+      # branch (the new pattern in 01-fetch / 02-sync).
+      - name: Reject mixed-credential laundering in workflow expressions
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=( .github/workflows/*.yml .github/workflows/*.yaml )
+          bad=""
+          for f in "${files[@]}"; do
+            # Pattern 1: STARS_TOKEN || GITHUB_TOKEN (any order, any whitespace).
+            hit1=$(grep -nE 'secrets\.STARS_TOKEN[[:space:]]*\|\|[[:space:]]*secrets\.GITHUB_TOKEN' "$f" || true)
+            hit2=$(grep -nE 'secrets\.GITHUB_TOKEN[[:space:]]*\|\|[[:space:]]*secrets\.STARS_TOKEN' "$f" || true)
+            # Pattern 2: app-token.outputs.token OR'd with any other secret.
+            hit3=$(grep -nE 'app-token\.outputs\.token[[:space:]]*\|\|[[:space:]]*secrets\.' "$f" || true)
+            for h in "$hit1" "$hit2" "$hit3"; do
+              if [ -n "$h" ]; then bad="${bad}${f}:\n${h}\n"; fi
+            done
+          done
+          if [ -n "$bad" ]; then
+            {
+              echo "::error::Mixed-credential laundering detected in workflow YAML."
+              echo "::error::A token slot must use exactly one credential class per run, selected by steps.doctor.outputs.selected_mode."
+              echo "::error::See session-oracle verdict rules 1-7 (PR adding strict 3-mode resolver)."
+              printf '%b' "$bad"
+            } >&2
+            exit 1
+          fi
+          echo "No mixed-credential expressions detected in workflow YAML."
+
+      # Per session-oracle verdict rule 8: blocked/private source NAMES
+      # must not surface in public outputs/summaries. The legacy
+      # `blocked_orgs` step output (a CSV of org names) is forbidden;
+      # use `blocked_orgs_count` instead.
+      - name: Reject leaked blocked-org names in workflow outputs
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=( .github/workflows/*.yml .github/workflows/*.yaml )
+          bad=""
+          for f in "${files[@]}"; do
+            # ^\s*blocked_orgs: ... (job/step output key, not _count).
+            hit=$(grep -nE "^[[:space:]]+blocked_orgs:[[:space:]]" "$f" || true)
+            if [ -n "$hit" ]; then bad="${bad}${f}:\n${hit}\n"; fi
+            # BLOCKED_ORGS env var (used to substitute names into summaries).
+            hit2=$(grep -nE "^[[:space:]]+BLOCKED_ORGS:[[:space:]]" "$f" || true)
+            if [ -n "$hit2" ]; then bad="${bad}${f}:\n${hit2}\n"; fi
+          done
+          if [ -n "$bad" ]; then
+            {
+              echo "::error::Workflow exposes blocked org NAMES in outputs/env. Use blocked_orgs_count (count only) per session-oracle verdict rule 8."
+              printf '%b' "$bad"
+            } >&2
+            exit 1
+          fi
+          echo "No blocked-org name leakage detected in workflow YAML."
+
       - name: workflow-lint summary
         if: always()
         run: |
@@ -140,6 +203,8 @@ jobs:
             echo ""
             echo "## Gates"
             echo "- cardinalby/schema-validator-action mode-value guard (rejects unsupported values)"
+            echo "- mixed-credential laundering guard (rejects \`STARS_TOKEN || GITHUB_TOKEN\` and \`app-token || secrets.\` patterns)"
+            echo "- blocked-org name leakage guard (rejects \`blocked_orgs\` output / \`BLOCKED_ORGS\` env in workflow YAML)"
             echo ""
             echo "actionlint runs inside \`pnpm gate\` (CI / gate job)."
             echo "Tracking issue for richer dry-run gates: #62"

--- a/.github/workflows/01-fetch-stars.yml
+++ b/.github/workflows/01-fetch-stars.yml
@@ -121,15 +121,17 @@ jobs:
           # If the resolver said github_app and the App step somehow didn't
           # mint, this resolves to empty and the CLI exits with a clear error.
           GH_TOKEN: ${{ (steps.doctor.outputs.selected_mode == 'github_app' && steps.app-token.outputs.token) || (steps.doctor.outputs.selected_mode == 'pat' && secrets.STARS_TOKEN) || (steps.doctor.outputs.selected_mode == 'github_token' && secrets.GITHUB_TOKEN) || '' }}
-          # Workflow_dispatch input flag, mirrored from doctor output for
-          # the runtime fallback layer to read (when implemented end-to-end).
+          # CLI branches on SELECTED_MODE: github_app uses REST
+          # /users/{STAR_SOURCE_USER}/starred (installation tokens have no
+          # user context); pat / github_token use GraphQL viewer.starredRepositories.
+          # See src/fetch/list-paginator-rest.ts header for citations.
+          SELECTED_MODE: ${{ steps.doctor.outputs.selected_mode }}
+          STAR_SOURCE_USER: ${{ steps.doctor.outputs.star_source_user }}
+          # Mirrored from doctor for the runtime fallback layer.
           PAT_FALLBACK_TO_GITHUB_TOKEN: ${{ steps.doctor.outputs.pat_fallback_to_github_token }}
-          # Available so the runtime fallback layer can switch to it if pat
-          # fails. Empty string when not in pat mode (so the runtime layer
-          # treats it as "no fallback target available").
+          # Fallback target for runtime-state.ts; empty when not in pat mode.
           GITHUB_TOKEN_FALLBACK: ${{ steps.doctor.outputs.selected_mode == 'pat' && secrets.GITHUB_TOKEN || '' }}
           RESUME_CURSOR: ${{ inputs.resume_cursor }}
-          SELECTED_MODE: ${{ steps.doctor.outputs.selected_mode }}
         run: pnpm fetch:stars
 
       - name: Upload results

--- a/.github/workflows/01-fetch-stars.yml
+++ b/.github/workflows/01-fetch-stars.yml
@@ -4,9 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       auth_mode:
-        description: 'auto | github_app | pat | public | github_token | disabled'
+        description: 'auto | github_app | pat | github_token'
         required: false
         default: 'auto'
+        type: choice
+        options:
+          - auto
+          - github_app
+          - pat
+          - github_token
+      pat_fallback_to_github_token:
+        description: 'When pat-mode is selected and PAT fails at runtime, fall back to GITHUB_TOKEN identity (loud, degraded). Set false to hard-fail instead. Ignored for non-pat modes.'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       resume_cursor:
         description: 'GraphQL endCursor to resume from. Leave blank to start from page 1.'
         required: false
@@ -26,11 +40,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      auth_mode: ${{ steps.doctor.outputs.auth_mode }}
+      selected_mode: ${{ steps.doctor.outputs.selected_mode }}
+      requested_mode: ${{ steps.doctor.outputs.requested_mode }}
       star_source_user: ${{ steps.doctor.outputs.star_source_user }}
+      # Per session-oracle verdict rule 7: star_fetch_auth and
+      # repo_write_auth ALWAYS equal selected_mode at config time.
+      # Workflow-lint validates this shape.
       star_fetch_auth: ${{ steps.doctor.outputs.star_fetch_auth }}
       repo_write_auth: ${{ steps.doctor.outputs.repo_write_auth }}
       degraded: ${{ steps.doctor.outputs.degraded }}
+      pat_fallback_to_github_token: ${{ steps.doctor.outputs.pat_fallback_to_github_token }}
       total_repos: ${{ steps.fetch.outputs.total_repos }}
       archived_count: ${{ steps.fetch.outputs.archived_count }}
       fork_count: ${{ steps.fetch.outputs.fork_count }}
@@ -41,7 +60,9 @@ jobs:
       resume_cursor: ${{ steps.fetch.outputs.resume_cursor }}
       pages_fetched: ${{ steps.fetch.outputs.pages_fetched }}
       batches_fetched: ${{ steps.fetch.outputs.batches_fetched }}
-      blocked_orgs: ${{ steps.fetch.outputs.blocked_orgs }}
+      # Per session-oracle verdict rule 8: COUNT only, no names. Org
+      # identifiers may be private/internal sources for the user.
+      blocked_orgs_count: ${{ steps.fetch.outputs.blocked_orgs_count }}
       artifact_name: fetched-stars-${{ github.run_id }}
 
     steps:
@@ -67,21 +88,6 @@ jobs:
           echo "::error::pnpm install failed after 3 attempts"
           exit 1
 
-      # Mint a GitHub App installation token when configured. The App
-      # cannot enumerate viewer.starredRepositories (installation tokens
-      # have no user context), so we mint it for repo-write operations
-      # only; star fetch still uses STARS_TOKEN or public mode per the
-      # auth resolver.
-      - name: Mint GitHub App token (when configured)
-        id: app-token
-        if: vars.GH_APP_CLIENT_ID != ''
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ vars.GH_APP_CLIENT_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
       - name: Resolve auth mode (setup-doctor)
         id: doctor
         env:
@@ -91,15 +97,39 @@ jobs:
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
           STARS_TOKEN: ${{ secrets.STARS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT_FALLBACK_TO_GITHUB_TOKEN: ${{ inputs.pat_fallback_to_github_token || 'true' }}
         run: pnpm auth:doctor
+
+      # Mint a GitHub App installation token ONLY when the resolver
+      # selected github_app mode. Keeps the credential boundary clean —
+      # no spare App token floating around when pat or github_token mode
+      # is in effect.
+      - name: Mint GitHub App token (selected_mode=github_app only)
+        id: app-token
+        if: steps.doctor.outputs.selected_mode == 'github_app'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Fetch starred repositories
         id: fetch
         env:
-          # Star-fetch token: PAT preferred (App can't paginate user.starred);
-          # falls back to GITHUB_TOKEN identity (degraded — fetches the bot's stars).
-          GH_TOKEN: ${{ secrets.STARS_TOKEN || secrets.GITHUB_TOKEN }}
+          # GH_TOKEN MUST equal selected_mode's credential. No silent fallback.
+          # If the resolver said github_app and the App step somehow didn't
+          # mint, this resolves to empty and the CLI exits with a clear error.
+          GH_TOKEN: ${{ (steps.doctor.outputs.selected_mode == 'github_app' && steps.app-token.outputs.token) || (steps.doctor.outputs.selected_mode == 'pat' && secrets.STARS_TOKEN) || (steps.doctor.outputs.selected_mode == 'github_token' && secrets.GITHUB_TOKEN) || '' }}
+          # Workflow_dispatch input flag, mirrored from doctor output for
+          # the runtime fallback layer to read (when implemented end-to-end).
+          PAT_FALLBACK_TO_GITHUB_TOKEN: ${{ steps.doctor.outputs.pat_fallback_to_github_token }}
+          # Available so the runtime fallback layer can switch to it if pat
+          # fails. Empty string when not in pat mode (so the runtime layer
+          # treats it as "no fallback target available").
+          GITHUB_TOKEN_FALLBACK: ${{ steps.doctor.outputs.selected_mode == 'pat' && secrets.GITHUB_TOKEN || '' }}
           RESUME_CURSOR: ${{ inputs.resume_cursor }}
+          SELECTED_MODE: ${{ steps.doctor.outputs.selected_mode }}
         run: pnpm fetch:stars
 
       - name: Upload results
@@ -118,11 +148,16 @@ jobs:
         if: success()
         id: commit
         env:
-          # Prefer GitHub App token for commits; fall back to STARS_TOKEN/GITHUB_TOKEN
-          # so existing setups continue to work while the App is being installed.
-          GIT_TOKEN: ${{ steps.app-token.outputs.token || secrets.STARS_TOKEN || secrets.GITHUB_TOKEN }}
+          # Per session-oracle verdict: commit token MUST equal selected_mode's
+          # credential. No more "App if present, else PAT, else GITHUB_TOKEN"
+          # ad-hoc chain — that was the laundering.
+          GIT_TOKEN: ${{ (steps.doctor.outputs.selected_mode == 'github_app' && steps.app-token.outputs.token) || (steps.doctor.outputs.selected_mode == 'pat' && secrets.STARS_TOKEN) || (steps.doctor.outputs.selected_mode == 'github_token' && secrets.GITHUB_TOKEN) || '' }}
         run: |
           set -euo pipefail
+          if [ -z "${GIT_TOKEN}" ]; then
+            echo "::error::GIT_TOKEN empty after auth resolution. selected_mode=${{ steps.doctor.outputs.selected_mode }}. This indicates an inconsistency between resolver and credential availability — fail loud."
+            exit 1
+          fi
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
@@ -141,7 +176,6 @@ jobs:
           fi
 
           git commit -m "chore: update starred repositories [skip ci]"
-          # Use the resolved token for push so we can use the GitHub App token when present.
           remote_url="https://x-access-token:${GIT_TOKEN}@github.com/${{ github.repository }}.git"
           pushed=false
           for attempt in 1 2 3 4 5; do
@@ -163,11 +197,13 @@ jobs:
       - name: Fetch summary
         if: always()
         env:
-          AUTH_MODE: ${{ steps.doctor.outputs.auth_mode }}
+          SELECTED_MODE: ${{ steps.doctor.outputs.selected_mode }}
+          REQUESTED_MODE: ${{ steps.doctor.outputs.requested_mode }}
           STAR_SOURCE_USER: ${{ steps.doctor.outputs.star_source_user }}
           STAR_FETCH_AUTH: ${{ steps.doctor.outputs.star_fetch_auth }}
           REPO_WRITE_AUTH: ${{ steps.doctor.outputs.repo_write_auth }}
           DEGRADED: ${{ steps.doctor.outputs.degraded }}
+          PAT_FALLBACK: ${{ steps.doctor.outputs.pat_fallback_to_github_token }}
           TOTAL: ${{ steps.fetch.outputs.total_repos }}
           ARCHIVED: ${{ steps.fetch.outputs.archived_count }}
           FORKS: ${{ steps.fetch.outputs.fork_count }}
@@ -178,7 +214,7 @@ jobs:
           PAGES_FETCHED: ${{ steps.fetch.outputs.pages_fetched }}
           BATCHES_FETCHED: ${{ steps.fetch.outputs.batches_fetched }}
           RESUME_CURSOR: ${{ steps.fetch.outputs.resume_cursor }}
-          BLOCKED_ORGS: ${{ steps.fetch.outputs.blocked_orgs }}
+          BLOCKED_ORGS_COUNT: ${{ steps.fetch.outputs.blocked_orgs_count }}
           INPUT_RESUME_CURSOR: ${{ inputs.resume_cursor }}
           ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
@@ -194,11 +230,15 @@ jobs:
             echo "- Trigger: \`${{ github.event_name }}\`"
             echo "- Commit: \`${{ github.sha }}\`"
             echo ""
-            echo "## Auth"
-            echo "- auth_mode: \`${AUTH_MODE:-unresolved}\`${DEGRADED:+ (degraded=$DEGRADED)}"
+            echo "## Auth (strict single-credential mode)"
+            echo "- selected_mode: \`${SELECTED_MODE:-unresolved}\`${DEGRADED:+ (degraded=$DEGRADED)}"
+            echo "- requested_mode: \`${REQUESTED_MODE:-?}\`"
             echo "- star_source_user: \`${STAR_SOURCE_USER:-unset}\`"
-            echo "- star_fetch_auth: \`${STAR_FETCH_AUTH:-?}\`"
-            echo "- repo_write_auth: \`${REPO_WRITE_AUTH:-?}\`"
+            echo "- star_fetch_auth: \`${STAR_FETCH_AUTH:-?}\` _(must equal selected_mode; verdict rule 7)_"
+            echo "- repo_write_auth: \`${REPO_WRITE_AUTH:-?}\` _(must equal selected_mode; verdict rule 7)_"
+            if [ "${SELECTED_MODE:-}" = "pat" ]; then
+              echo "- pat_fallback_to_github_token: \`${PAT_FALLBACK:-true}\`"
+            fi
             if [ -n "${INPUT_RESUME_CURSOR:-}" ]; then
               echo "- Resumed from cursor: \`${INPUT_RESUME_CURSOR:0:24}…\`"
             fi
@@ -208,8 +248,9 @@ jobs:
             echo "- Archived: \`${ARCHIVED:-?}\`"
             echo "- Forks: \`${FORKS:-?}\`"
             echo "- No description: \`${NO_DESC:-?}\`"
-            if [ -n "${BLOCKED_ORGS:-}" ]; then
-              echo "- Skipped orgs (classic-PAT blocked): \`${BLOCKED_ORGS}\`"
+            if [ -n "${BLOCKED_ORGS_COUNT:-}" ] && [ "${BLOCKED_ORGS_COUNT}" != "0" ]; then
+              # Per session-oracle verdict rule 8: count only, names redacted.
+              echo "- Skipped orgs (classic-PAT blocked): \`${BLOCKED_ORGS_COUNT}\` _(names redacted from public log)_"
             fi
             echo ""
             echo "## Outputs"

--- a/.github/workflows/02-sync-stars.yml
+++ b/.github/workflows/02-sync-stars.yml
@@ -4,6 +4,24 @@ name: '02-Sync Starred Repos'
 on:
   workflow_dispatch:
     inputs:
+      auth_mode:
+        description: 'auto | github_app | pat | github_token'
+        required: false
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - github_app
+          - pat
+          - github_token
+      pat_fallback_to_github_token:
+        description: 'When pat-mode is selected and PAT fails at runtime, fall back to GITHUB_TOKEN identity (loud, degraded). Set false to hard-fail instead.'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       removal_override:
         description: 'Set true to bypass the 5% destructive-deletion guard'
         required: false
@@ -20,9 +38,7 @@ permissions:
 
 concurrency:
   # All runs ultimately mutate `main` (Checkout + push below is hardcoded
-  # to `ref: main`), so use a constant group instead of `github.ref` so
-  # workflow_dispatch from a non-main ref still serializes against
-  # workflow_run-triggered sync runs.
+  # to `ref: main`), so use a constant group instead of `github.ref`.
   group: sync-stars-main
   cancel-in-progress: false
 
@@ -61,12 +77,21 @@ jobs:
           echo "::error::pnpm install failed after 3 attempts"
           exit 1
 
-      # Mint a GitHub App installation token when configured. Used for
-      # the commit/push at the end so we can stop relying on
-      # github-actions[bot] identity.
-      - name: Mint GitHub App token (when configured)
+      - name: Resolve auth mode (setup-doctor)
+        id: doctor
+        env:
+          AUTH_MODE_REQUEST: ${{ inputs.auth_mode || 'auto' }}
+          STAR_SOURCE_USER: ${{ vars.STAR_SOURCE_USER || 'primeinc' }}
+          GH_APP_CLIENT_ID: ${{ vars.GH_APP_CLIENT_ID }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          STARS_TOKEN: ${{ secrets.STARS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT_FALLBACK_TO_GITHUB_TOKEN: ${{ inputs.pat_fallback_to_github_token || 'true' }}
+        run: pnpm auth:doctor
+
+      - name: Mint GitHub App token (selected_mode=github_app only)
         id: app-token
-        if: vars.GH_APP_CLIENT_ID != ''
+        if: steps.doctor.outputs.selected_mode == 'github_app'
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.GH_APP_CLIENT_ID }}
@@ -75,11 +100,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
 
       - name: Validate existing manifest (schema gate)
-        # cardinalby/schema-validator-action@v3 mode values are
-        # `default | lax | strong | spec` (per action.yml; uses schemasafe
-        # under the hood). There is NO `strict`. `default` enforces the
-        # schema's `additionalProperties: false`, required fields, types,
-        # enums, and patterns. See `.sisyphus/proofs/02M-mode-correction.md`.
         if: hashFiles('repos.yml') != ''
         uses: cardinalby/schema-validator-action@v3
         with:
@@ -127,9 +147,6 @@ jobs:
           TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
-          # In workflow_run mode the artifact is the canonical handoff. If
-          # the download did not succeed, fail hard instead of silently
-          # reconciling against potentially-stale committed data.
           if [ "$MODE" = "artifact" ] && [ "$DOWNLOAD_OUTCOME" != "success" ]; then
             {
               echo "::error::Artifact download failed for triggering run $TRIGGER_RUN_ID (artifact=$ARTIFACT_NAME, outcome=$DOWNLOAD_OUTCOME)."
@@ -177,10 +194,15 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         id: commit
         env:
-          # Prefer GitHub App token; fall back to GITHUB_TOKEN.
-          GIT_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          # Per session-oracle verdict: commit token MUST equal selected_mode's
+          # credential. No `||` ad-hoc chain — that was the laundering.
+          GIT_TOKEN: ${{ (steps.doctor.outputs.selected_mode == 'github_app' && steps.app-token.outputs.token) || (steps.doctor.outputs.selected_mode == 'pat' && secrets.STARS_TOKEN) || (steps.doctor.outputs.selected_mode == 'github_token' && secrets.GITHUB_TOKEN) || '' }}
         run: |
           set -euo pipefail
+          if [ -z "${GIT_TOKEN}" ]; then
+            echo "::error::GIT_TOKEN empty after auth resolution. selected_mode=${{ steps.doctor.outputs.selected_mode }}. Inconsistency between resolver and credential availability — fail loud."
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add repos.yml
@@ -210,6 +232,10 @@ jobs:
       - name: Sync summary
         if: always()
         env:
+          SELECTED_MODE: ${{ steps.doctor.outputs.selected_mode }}
+          STAR_FETCH_AUTH: ${{ steps.doctor.outputs.star_fetch_auth }}
+          REPO_WRITE_AUTH: ${{ steps.doctor.outputs.repo_write_auth }}
+          DEGRADED: ${{ steps.doctor.outputs.degraded }}
           INPUT_SOURCE: ${{ steps.input.outputs.source }}
           INPUT_BYTES: ${{ steps.input.outputs.input_bytes }}
           ARTIFACT_NAME: ${{ steps.source.outputs.artifact_name }}
@@ -223,7 +249,6 @@ jobs:
           TOTAL_REPOS: ${{ steps.diff.outputs.total_repos }}
           COMMIT_PUSHED: ${{ steps.commit.outputs.pushed }}
           COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
-          APP_TOKEN_USED: ${{ steps.app-token.outputs.token != '' }}
         run: |
           {
             echo "# 02 — Sync"
@@ -233,7 +258,11 @@ jobs:
             echo "- Trigger: \`${{ github.event_name }}\`"
             echo "- Triggering run: \`${TRIGGER_RUN_ID:-n/a}\`"
             echo "- Commit: \`${{ github.sha }}\`"
-            echo "- GitHub App token used for commit: \`${APP_TOKEN_USED:-false}\`"
+            echo ""
+            echo "## Auth (strict single-credential mode)"
+            echo "- selected_mode: \`${SELECTED_MODE:-unresolved}\`${DEGRADED:+ (degraded=$DEGRADED)}"
+            echo "- star_fetch_auth: \`${STAR_FETCH_AUTH:-?}\` _(must equal selected_mode)_"
+            echo "- repo_write_auth: \`${REPO_WRITE_AUTH:-?}\` _(must equal selected_mode)_"
             echo ""
             echo "## Inputs"
             echo "- Source: \`${INPUT_SOURCE:-unresolved}\`"

--- a/src/auth/auth-mode.ts
+++ b/src/auth/auth-mode.ts
@@ -1,17 +1,28 @@
-// Auth mode types for the github-stars control plane.
+// Strict single-credential auth modes per the session-oracle verdict.
 //
-// Per issue #69 doctrine: repo_write_auth != star_fetch_auth.
-// One credential decision drives commits/PRs against this repo;
-// a separate decision drives the GraphQL star fetch.
+// The doctrine — verbatim from the patch mandate:
 //
-// Modes are explicit and named; no implicit fallback. The resolver
-// in resolve-auth-mode.ts maps env+inputs -> ResolvedAuth, and the
-// workflow consumes the resolution via setup-doctor's typed output.
+//   1. Auto selects the highest-ranked configured mode:
+//        github_app -> pat -> github_token.
+//   2. A selected mode owns ALL auth roles for the run.
+//   3. No role may borrow another mode's credential.
+//   4. github_app failure hard-fails by default.
+//   5. pat failure falls back to github_token by default,
+//      with a config flag to hard-fail.
+//   6. Fallback is represented as effective_mode=github_token,
+//      never as mixed role auth.
+//   7. Any summary with star_fetch_auth != repo_write_auth fails validation.
+//   8. Public logs/artifacts MUST NOT expose blocked/private source names.
+//
+// The previous design (where `auth_mode=github_app` could quietly use a
+// PAT for star fetch while using the App for write) was credential-class
+// laundering. This file prevents that combination from being expressible
+// in the type system, and assertNoMixedAuth() enforces it at runtime.
 
-export const AUTH_MODES = ['github_app', 'pat', 'public', 'github_token', 'disabled'] as const;
+export const AUTH_MODES = ['github_app', 'pat', 'github_token'] as const;
 export type AuthMode = (typeof AUTH_MODES)[number];
 
-/** Inputs to the resolver. All fields optional; resolver decides. */
+/** Inputs to the resolver. Resolver decides; never mixes. */
 export type AuthResolverInputs = {
   /** workflow_dispatch input or schedule default. 'auto' = resolver picks. */
   requested_mode?: AuthMode | 'auto';
@@ -23,35 +34,82 @@ export type AuthResolverInputs = {
   has_gh_app_private_key?: boolean;
   has_stars_token?: boolean;
   has_github_token?: boolean;
-};
 
-/** What the resolver decides for one role (fetch vs write). */
-export type RoleAuth =
-  | { source: 'github_app' }
-  | { source: 'pat' }
-  | { source: 'public' }
-  | { source: 'github_token' }
-  | { source: 'none' };
-
-/** Final resolution. Workflow reads these outputs as job-level outputs. */
-export type ResolvedAuth = {
-  auth_mode: AuthMode;
-  star_source_user: string;
-  star_fetch_auth: RoleAuth;
-  repo_write_auth: RoleAuth;
-  /** True when a fallback was used because the preferred mode was unavailable. */
-  degraded: boolean;
-  /** Human-readable reason for the chosen mode (or for the fail). */
-  reason: string;
-  /** Names of required-but-missing config keys when auth_mode === 'disabled'. */
-  missing_config: string[];
   /**
-   * Capability matrix the doctor surfaces in $GITHUB_STEP_SUMMARY.
-   * No values, only yes/no/blocked.
+   * Allow loud fallback from `pat` to `github_token` when PAT is broken
+   * at runtime. Default: true. github_app NEVER falls back; if it can't
+   * do the work, the run hard-fails.
    */
-  capabilities: {
-    can_mint_app_token: 'yes' | 'no' | 'blocked';
-    can_fetch_star_page: 'yes' | 'no' | 'blocked';
-    can_checkout_target_repo: 'yes' | 'no' | 'blocked';
-  };
+  pat_fallback_to_github_token?: boolean;
+
+  /**
+   * Whether the github_app credential class can actually serve the
+   * star_fetch role end-to-end. Default false until the REST-based
+   * /users/{user}/starred fetch path is wired up under App mode.
+   * When false, AUTO will skip github_app and pick the next mode whose
+   * credentials are present (pat -> github_token), even if App config
+   * is fully present. EXPLICIT `auth_mode: github_app` still selects
+   * the App and will hard-fail at fetch time per doctrine.
+   *
+   * Set explicitly via env GITHUB_APP_SUPPORTS_FETCH=true once the
+   * App-fetch path lands; defaults false to avoid breaking the daily
+   * cron with an installation-token-can't-read-viewer error.
+   */
+  github_app_supports_fetch?: boolean;
 };
+
+/**
+ * The selected mode determines the credential class used for every role.
+ * No role-by-role variation exists. star_fetch and repo_write are derived,
+ * not configured — they are always the same as `selected_mode`'s class.
+ */
+export type ResolvedAuth = {
+  /** What the user/auto requested. */
+  requested_mode: AuthMode | 'auto';
+  /** What the resolver chose at config time. Owns every role. */
+  selected_mode: AuthMode;
+  /** Same as selected_mode at config time. effective_mode may differ at
+   *  runtime if a fallback transition fires (see runtime-state.ts). */
+  star_fetch_auth: AuthMode;
+  repo_write_auth: AuthMode;
+  /** Passthrough — which user's stars to fetch. Not part of auth decision. */
+  star_source_user: string;
+  /**
+   * For `pat` mode: whether a runtime fallback to `github_token` is allowed
+   * if PAT is broken. Default true. Surfaced so the workflow can branch.
+   */
+  pat_fallback_to_github_token: boolean;
+  /** True when selected_mode is `github_token` (always degraded). */
+  degraded: boolean;
+  reason: string;
+  /** When selected_mode cannot be picked at all — names what's missing. */
+  missing_config: string[];
+};
+
+/**
+ * Runtime fallback transition. Emitted ONLY when `pat` mode fires and
+ * its credential is broken at runtime AND `pat_fallback_to_github_token`
+ * is true. Represents the transition explicitly — never a hidden role swap.
+ */
+export type EffectiveAuth = ResolvedAuth & {
+  effective_mode: AuthMode;
+  /** True iff effective_mode != selected_mode (a transition happened). */
+  fallback_fired: boolean;
+};
+
+/**
+ * Runtime guard. Any code path that produces a ResolvedAuth or
+ * EffectiveAuth where star_fetch_auth != repo_write_auth must fail
+ * loudly. This is the load-bearing check. The type system makes
+ * mixed-role auth unrepresentable for ResolvedAuth (both fields derive
+ * from `selected_mode`); this asserts it for arbitrary inputs.
+ */
+export function assertNoMixedAuth(auth: { star_fetch_auth: string; repo_write_auth: string }): void {
+  if (auth.star_fetch_auth !== auth.repo_write_auth) {
+    throw new Error(
+      `Invalid mixed auth boundary: star_fetch_auth=${auth.star_fetch_auth}, ` +
+        `repo_write_auth=${auth.repo_write_auth}. ` +
+        `A selected mode must own every role.`
+    );
+  }
+}

--- a/src/auth/auth-mode.ts
+++ b/src/auth/auth-mode.ts
@@ -43,17 +43,16 @@ export type AuthResolverInputs = {
   pat_fallback_to_github_token?: boolean;
 
   /**
-   * Whether the github_app credential class can actually serve the
-   * star_fetch role end-to-end. Default false until the REST-based
-   * /users/{user}/starred fetch path is wired up under App mode.
-   * When false, AUTO will skip github_app and pick the next mode whose
-   * credentials are present (pat -> github_token), even if App config
-   * is fully present. EXPLICIT `auth_mode: github_app` still selects
-   * the App and will hard-fail at fetch time per doctrine.
+   * Whether the github_app credential class can serve the star_fetch
+   * role end-to-end. The App-fetch path uses REST
+   * /users/{username}/starred which is `serverToServer: true` per
+   * first-party docs (refs/github/docs/.../activity.json L95321-95330).
+   * See src/fetch/list-paginator-rest.ts for the implementation
+   * + cited progAccess block.
    *
-   * Set explicitly via env GITHUB_APP_SUPPORTS_FETCH=true once the
-   * App-fetch path lands; defaults false to avoid breaking the daily
-   * cron with an installation-token-can't-read-viewer error.
+   * Defaults TRUE — the path is implemented and verified. Set
+   * GITHUB_APP_SUPPORTS_FETCH=false to force AUTO to skip github_app
+   * (e.g. while debugging an issue with the REST path).
    */
   github_app_supports_fetch?: boolean;
 };

--- a/src/auth/resolve-auth-mode.test.ts
+++ b/src/auth/resolve-auth-mode.test.ts
@@ -1,109 +1,183 @@
 import { describe, expect, it } from 'vitest';
-import { resolveAuthMode } from './resolve-auth-mode.js';
+import { AuthConfigError, resolveAuthMode } from './resolve-auth-mode.js';
+import { assertNoMixedAuth } from './auth-mode.js';
 
 const base = { star_source_user: 'primeinc' };
 
-describe('resolveAuthMode — auto', () => {
-  it('prefers github_app when both app credentials present', () => {
-    const r = resolveAuthMode({ ...base, has_gh_app_client_id: true, has_gh_app_private_key: true, has_stars_token: true });
-    expect(r.auth_mode).toBe('github_app');
-    expect(r.repo_write_auth.source).toBe('github_app');
+describe('resolveAuthMode — auto priority', () => {
+  it('App configured + github_app_supports_fetch=true + PAT → selected_mode=github_app, no PAT reference', () => {
+    // Arrange
+    const inputs = {
+      ...base,
+      has_gh_app_client_id: true,
+      has_gh_app_private_key: true,
+      github_app_supports_fetch: true,
+      has_stars_token: true,
+      has_github_token: true,
+    };
+    // Act
+    const r = resolveAuthMode(inputs);
+    // Assert
+    expect(r.selected_mode).toBe('github_app');
+    expect(r.star_fetch_auth).toBe('github_app');
+    expect(r.repo_write_auth).toBe('github_app');
     expect(r.degraded).toBe(false);
-    // Star fetch under app mode falls through to PAT (apps can't read user.starredRepositories with installation tokens).
-    expect(r.star_fetch_auth.source).toBe('pat');
+    expect(r.pat_fallback_to_github_token).toBe(false); // not pat mode
   });
 
-  it('falls back to pat when only PAT is present', () => {
+  it('App configured but github_app_supports_fetch=false + PAT → selected_mode=pat (auto skips App)', () => {
+    // Doctrine: auto must not pick a mode that cannot complete every role.
+    // The runtime fact that the App can't read viewer.starredRepositories
+    // is encoded as github_app_supports_fetch=false (default) until the
+    // App-fetch path is implemented.
+    const inputs = {
+      ...base,
+      has_gh_app_client_id: true,
+      has_gh_app_private_key: true,
+      github_app_supports_fetch: false,
+      has_stars_token: true,
+    };
+    const r = resolveAuthMode(inputs);
+    expect(r.selected_mode).toBe('pat');
+    expect(r.reason).toContain('github_app_supports_fetch=false');
+  });
+
+  it('App configured but github_app_supports_fetch=false + no PAT → falls all the way to github_token', () => {
+    const r = resolveAuthMode({
+      ...base,
+      has_gh_app_client_id: true,
+      has_gh_app_private_key: true,
+      has_github_token: true,
+      github_app_supports_fetch: false,
+    });
+    expect(r.selected_mode).toBe('github_token');
+  });
+
+  it('explicit github_app is still allowed even when github_app_supports_fetch=false (per doctrine: hard-fail at runtime)', () => {
+    // Auto skips the App; but if the user explicitly asks for it, the
+    // resolver MUST select it. The runtime then hard-fails loudly when
+    // the App can't read viewer.starredRepositories — that IS the doctrine.
+    const r = resolveAuthMode({
+      ...base,
+      requested_mode: 'github_app',
+      has_gh_app_client_id: true,
+      has_gh_app_private_key: true,
+      github_app_supports_fetch: false,
+    });
+    expect(r.selected_mode).toBe('github_app');
+  });
+
+  it('PAT configured (App absent) → selected_mode=pat, pat owns all roles', () => {
     const r = resolveAuthMode({ ...base, has_stars_token: true });
-    expect(r.auth_mode).toBe('pat');
-    expect(r.degraded).toBe(true);
-    expect(r.star_fetch_auth.source).toBe('pat');
-    expect(r.repo_write_auth.source).toBe('pat');
+    expect(r.selected_mode).toBe('pat');
+    expect(r.star_fetch_auth).toBe('pat');
+    expect(r.repo_write_auth).toBe('pat');
+    expect(r.pat_fallback_to_github_token).toBe(true); // default on
   });
 
-  it('falls back to public when only star_source_user is set', () => {
-    const r = resolveAuthMode({ ...base });
-    expect(r.auth_mode).toBe('public');
-    expect(r.degraded).toBe(true);
-    expect(r.star_fetch_auth.source).toBe('public');
-    // No write auth available in pure public mode.
-    expect(r.repo_write_auth.source).toBe('none');
-  });
-
-  it('uses github_token as last resort when no user is configured', () => {
+  it('Only GITHUB_TOKEN → selected_mode=github_token, degraded=true', () => {
     const r = resolveAuthMode({ has_github_token: true });
-    expect(r.auth_mode).toBe('github_token');
+    expect(r.selected_mode).toBe('github_token');
+    expect(r.star_fetch_auth).toBe('github_token');
+    expect(r.repo_write_auth).toBe('github_token');
     expect(r.degraded).toBe(true);
-    expect(r.reason).toContain('GITHUB_TOKEN');
   });
 
-  it('returns disabled when nothing usable', () => {
-    const r = resolveAuthMode({});
-    expect(r.auth_mode).toBe('disabled');
-    expect(r.capabilities.can_fetch_star_page).toBe('blocked');
+  it('No credentials at all → throws AuthConfigError naming what is missing', () => {
+    expect(() => resolveAuthMode({})).toThrow(AuthConfigError);
   });
 
-  it('public + github_token → public wins, write uses GITHUB_TOKEN', () => {
-    const r = resolveAuthMode({ ...base, has_github_token: true });
-    expect(r.auth_mode).toBe('public');
-    expect(r.repo_write_auth.source).toBe('github_token');
+  it('Auto: when App auto-picks (supports_fetch=true), no PAT reference appears', () => {
+    // Regression test for the prior bug where github_app + STARS_TOKEN
+    // produced auth_mode=github_app + star_fetch_auth=pat.
+    const r = resolveAuthMode({
+      ...base,
+      has_gh_app_client_id: true,
+      has_gh_app_private_key: true,
+      github_app_supports_fetch: true,
+      has_stars_token: true,
+    });
+    expect(r.selected_mode).toBe('github_app');
+    expect(r.star_fetch_auth).not.toBe('pat');
+    expect(r.repo_write_auth).not.toBe('pat');
   });
 });
 
 describe('resolveAuthMode — explicit modes', () => {
-  it('explicit github_app + missing private key → disabled with named gap', () => {
-    const r = resolveAuthMode({ ...base, requested_mode: 'github_app', has_gh_app_client_id: true });
-    expect(r.auth_mode).toBe('disabled');
-    expect(r.missing_config).toEqual(['GH_APP_PRIVATE_KEY']);
-    expect(r.capabilities.can_mint_app_token).toBe('blocked');
+  it('explicit github_app + missing private key → AuthConfigError', () => {
+    expect(() =>
+      resolveAuthMode({ ...base, requested_mode: 'github_app', has_gh_app_client_id: true })
+    ).toThrow(AuthConfigError);
   });
 
-  it('explicit pat + missing STARS_TOKEN → disabled with named gap', () => {
-    const r = resolveAuthMode({ ...base, requested_mode: 'pat' });
-    expect(r.auth_mode).toBe('disabled');
-    expect(r.missing_config).toEqual(['STARS_TOKEN']);
+  it('explicit pat + missing STARS_TOKEN → AuthConfigError', () => {
+    expect(() => resolveAuthMode({ ...base, requested_mode: 'pat' })).toThrow(AuthConfigError);
   });
 
-  it('explicit public + no user → disabled', () => {
-    const r = resolveAuthMode({ requested_mode: 'public' });
-    expect(r.auth_mode).toBe('disabled');
-    expect(r.missing_config).toEqual(['STAR_SOURCE_USER']);
+  it('explicit github_token + missing GITHUB_TOKEN → AuthConfigError', () => {
+    expect(() => resolveAuthMode({ requested_mode: 'github_token' })).toThrow(AuthConfigError);
   });
 
-  it('explicit pat with PAT present → pat (NOT degraded)', () => {
-    const r = resolveAuthMode({ ...base, requested_mode: 'pat', has_stars_token: true });
-    expect(r.auth_mode).toBe('pat');
-    expect(r.degraded).toBe(false);
+  it('explicit github_app + valid → selected_mode=github_app even when PAT also present', () => {
+    const r = resolveAuthMode({
+      ...base,
+      requested_mode: 'github_app',
+      has_gh_app_client_id: true,
+      has_gh_app_private_key: true,
+      has_stars_token: true,
+    });
+    expect(r.selected_mode).toBe('github_app');
+    expect(r.star_fetch_auth).toBe('github_app');
+    expect(r.repo_write_auth).toBe('github_app');
   });
 
-  it('explicit github_token still flagged degraded with reason', () => {
-    const r = resolveAuthMode({ ...base, requested_mode: 'github_token', has_github_token: true });
-    expect(r.auth_mode).toBe('github_token');
-    expect(r.degraded).toBe(true);
-  });
-
-  it('explicit disabled → disabled with reason', () => {
-    const r = resolveAuthMode({ requested_mode: 'disabled' });
-    expect(r.auth_mode).toBe('disabled');
-    expect(r.reason).toContain('disabled by request');
+  it('explicit pat with pat_fallback_to_github_token=false → fallback flag respected', () => {
+    const r = resolveAuthMode({
+      ...base,
+      requested_mode: 'pat',
+      has_stars_token: true,
+      pat_fallback_to_github_token: false,
+    });
+    expect(r.selected_mode).toBe('pat');
+    expect(r.pat_fallback_to_github_token).toBe(false);
   });
 });
 
-describe('resolveAuthMode — capabilities matrix', () => {
-  it('reports can_mint_app_token=yes only under github_app', () => {
-    const app = resolveAuthMode({ ...base, has_gh_app_client_id: true, has_gh_app_private_key: true });
-    expect(app.capabilities.can_mint_app_token).toBe('yes');
-    const pat = resolveAuthMode({ ...base, has_stars_token: true });
-    expect(pat.capabilities.can_mint_app_token).toBe('no');
+describe('resolveAuthMode — invariant: no mixed-role auth is constructible', () => {
+  it('every resolved auth has star_fetch_auth === repo_write_auth', () => {
+    const cases = [
+      // App auto-picked (supports_fetch=true)
+      { ...base, has_gh_app_client_id: true, has_gh_app_private_key: true, github_app_supports_fetch: true },
+      // PAT auto
+      { ...base, has_stars_token: true },
+      // GITHUB_TOKEN auto
+      { has_github_token: true },
+      // App config present + PAT — auto skips App because supports_fetch=false
+      { ...base, has_gh_app_client_id: true, has_gh_app_private_key: true, has_stars_token: true, has_github_token: true },
+      // Explicit pat
+      { ...base, requested_mode: 'pat' as const, has_stars_token: true },
+      // Explicit github_app even when supports_fetch=false (selectable; will hard-fail at runtime)
+      { ...base, requested_mode: 'github_app' as const, has_gh_app_client_id: true, has_gh_app_private_key: true, github_app_supports_fetch: false },
+    ];
+    for (const inputs of cases) {
+      const r = resolveAuthMode(inputs);
+      expect(r.star_fetch_auth, `${JSON.stringify(inputs)}`).toBe(r.repo_write_auth);
+    }
   });
+});
 
-  it('reports can_checkout_target_repo=yes when any write auth is available', () => {
-    const r = resolveAuthMode({ ...base, has_stars_token: true });
-    expect(r.capabilities.can_checkout_target_repo).toBe('yes');
+describe('assertNoMixedAuth — runtime guard', () => {
+  it('passes when both roles match', () => {
+    expect(() => assertNoMixedAuth({ star_fetch_auth: 'pat', repo_write_auth: 'pat' })).not.toThrow();
   });
-
-  it('reports can_checkout_target_repo=blocked when no write auth at all', () => {
-    const r = resolveAuthMode({ ...base });
-    expect(r.capabilities.can_checkout_target_repo).toBe('blocked');
+  it('throws on the laundering shape (github_app + pat)', () => {
+    expect(() =>
+      assertNoMixedAuth({ star_fetch_auth: 'pat', repo_write_auth: 'github_app' })
+    ).toThrow(/Invalid mixed auth boundary/);
+  });
+  it('throws on any unequal pair', () => {
+    expect(() =>
+      assertNoMixedAuth({ star_fetch_auth: 'github_token', repo_write_auth: 'pat' })
+    ).toThrow();
   });
 });

--- a/src/auth/resolve-auth-mode.ts
+++ b/src/auth/resolve-auth-mode.ts
@@ -1,147 +1,139 @@
-// Pure resolver: env+inputs -> ResolvedAuth.
+// Strict 3-mode resolver. No credential mixing. Per session-oracle verdict.
 //
-// Priority for `auto`:
-//   1. github_app  if both client id + private key present
-//   2. pat         if STARS_TOKEN present
-//   3. public      if star_source_user present
-//   4. github_token always degraded; only when nothing else applies
-//   5. disabled    when nothing usable
+// Auto priority (presence of credentials only — no capability tests here;
+// runtime is where capability is proven):
+//   1. github_app  — both GH_APP_CLIENT_ID and GH_APP_PRIVATE_KEY present
+//   2. pat         — STARS_TOKEN present
+//   3. github_token — GITHUB_TOKEN present (always degraded; always loud)
 //
-// When the user explicitly requests a mode, only that mode is considered;
-// missing config -> disabled with explicit missing_config list (never silent fallback).
+// When the user explicitly requests a mode, only that mode is considered.
+// Missing config => `disabled`-ish reason via missing_config + a thrown
+// error from the workflow when auth_mode cannot be picked.
+//
+// Behavior on runtime failure (NOT decided here — decided by the runtime
+// fallback layer in runtime-state.ts):
+//   - github_app fails  -> hard fail. ALWAYS. No fallback. Ever.
+//   - pat fails         -> if pat_fallback_to_github_token (default true),
+//                          loud transition to effective_mode=github_token;
+//                          else hard fail.
+//   - github_token fails -> hard fail.
 
-import type { AuthResolverInputs, ResolvedAuth, RoleAuth } from './auth-mode.js';
+import { assertNoMixedAuth, type AuthMode, type AuthResolverInputs, type ResolvedAuth } from './auth-mode.js';
 
-const NO_AUTH: RoleAuth = { source: 'none' };
-
-export function resolveAuthMode(inputs: AuthResolverInputs): ResolvedAuth {
-  const star_source_user = (inputs.star_source_user || '').trim();
-  const requested = inputs.requested_mode || 'auto';
-
-  if (requested !== 'auto') {
-    return resolveExplicit(requested, inputs, star_source_user);
+export class AuthConfigError extends Error {
+  constructor(
+    message: string,
+    readonly missing_config: string[]
+  ) {
+    super(message);
+    this.name = 'AuthConfigError';
   }
-
-  if (inputs.has_gh_app_client_id && inputs.has_gh_app_private_key) {
-    return ok('github_app', star_source_user, inputs, false, 'preferred mode (GitHub App configured)');
-  }
-  if (inputs.has_stars_token) {
-    return ok('pat', star_source_user, inputs, true, 'STARS_TOKEN present, GitHub App not configured');
-  }
-  if (star_source_user) {
-    return ok('public', star_source_user, inputs, true, 'no PAT and no App; falling back to public source');
-  }
-  if (inputs.has_github_token) {
-    return ok('github_token', star_source_user, inputs, true,
-      'last-resort: GITHUB_TOKEN identity will be used; this fetches the bot account stars, not the configured user');
-  }
-  return disabled(inputs, 'no usable credentials and no STAR_SOURCE_USER configured');
 }
 
-function resolveExplicit(mode: ResolvedAuth['auth_mode'], inputs: AuthResolverInputs, user: string): ResolvedAuth {
+export function resolveAuthMode(inputs: AuthResolverInputs): ResolvedAuth {
+  const requested = inputs.requested_mode || 'auto';
+  // Default true: PAT-mode runs prefer to keep going under github_token
+  // if the PAT is broken (better degraded-but-running than not running).
+  // The user can set it false to make PAT failure a hard stop.
+  const pat_fallback = inputs.pat_fallback_to_github_token !== false;
+
+  if (requested !== 'auto') {
+    return resolveExplicit(requested, inputs, pat_fallback);
+  }
+
+  // Auto: highest-ranked mode whose REQUIRED credentials are present
+  // AND which can actually serve every role end-to-end.
+  //
+  // Special case for github_app: until the App-based star fetch path
+  // is wired up (see `github_app_supports_fetch` flag in auth-mode.ts),
+  // AUTO must skip github_app even when its credentials are present.
+  // Otherwise the daily cron hard-fails at fetch time because the App
+  // installation token cannot read viewer.starredRepositories. EXPLICIT
+  // `auth_mode: github_app` still selects the App and is allowed to
+  // hard-fail per doctrine — but auto will never pick a mode it knows
+  // cannot complete.
+  if (
+    inputs.has_gh_app_client_id &&
+    inputs.has_gh_app_private_key &&
+    inputs.github_app_supports_fetch === true
+  ) {
+    return build('github_app', inputs, pat_fallback,
+      'auto: GitHub App credentials present and github_app_supports_fetch=true');
+  }
+  if (inputs.has_stars_token) {
+    const reason =
+      inputs.has_gh_app_client_id && inputs.has_gh_app_private_key
+        ? 'auto: STARS_TOKEN present; GitHub App configured but github_app_supports_fetch=false (App-fetch path not yet implemented)'
+        : 'auto: STARS_TOKEN present, GitHub App not configured';
+    return build('pat', inputs, pat_fallback, reason);
+  }
+  if (inputs.has_github_token) {
+    return build('github_token', inputs, pat_fallback,
+      'auto: only GITHUB_TOKEN available — degraded mode');
+  }
+
+  // Nothing usable.
+  throw new AuthConfigError(
+    'No usable auth credentials. Need at least one of: ' +
+      'GH_APP_CLIENT_ID + GH_APP_PRIVATE_KEY, STARS_TOKEN, or GITHUB_TOKEN.',
+    ['GH_APP_CLIENT_ID|STARS_TOKEN|GITHUB_TOKEN']
+  );
+}
+
+function resolveExplicit(mode: AuthMode, inputs: AuthResolverInputs, pat_fallback: boolean): ResolvedAuth {
   switch (mode) {
     case 'github_app': {
       const missing: string[] = [];
       if (!inputs.has_gh_app_client_id) missing.push('GH_APP_CLIENT_ID');
       if (!inputs.has_gh_app_private_key) missing.push('GH_APP_PRIVATE_KEY');
-      if (missing.length) return disabled(inputs, `github_app explicitly requested but missing: ${missing.join(', ')}`, missing);
-      return ok('github_app', user, inputs, false, 'github_app explicitly requested');
+      if (missing.length) {
+        throw new AuthConfigError(
+          `Explicit github_app requested but missing: ${missing.join(', ')}`,
+          missing
+        );
+      }
+      return build('github_app', inputs, pat_fallback, 'explicit: github_app');
     }
     case 'pat': {
-      if (!inputs.has_stars_token) return disabled(inputs, 'pat explicitly requested but STARS_TOKEN missing', ['STARS_TOKEN']);
-      return ok('pat', user, inputs, false, 'pat explicitly requested');
-    }
-    case 'public': {
-      if (!user) return disabled(inputs, 'public explicitly requested but STAR_SOURCE_USER missing', ['STAR_SOURCE_USER']);
-      return ok('public', user, inputs, false, 'public explicitly requested');
+      if (!inputs.has_stars_token) {
+        throw new AuthConfigError(
+          'Explicit pat requested but STARS_TOKEN missing',
+          ['STARS_TOKEN']
+        );
+      }
+      return build('pat', inputs, pat_fallback, 'explicit: pat');
     }
     case 'github_token': {
-      if (!inputs.has_github_token) return disabled(inputs, 'github_token explicitly requested but no GITHUB_TOKEN available', ['GITHUB_TOKEN']);
-      return ok('github_token', user, inputs, true, 'github_token explicitly requested (degraded)');
+      if (!inputs.has_github_token) {
+        throw new AuthConfigError(
+          'Explicit github_token requested but GITHUB_TOKEN missing',
+          ['GITHUB_TOKEN']
+        );
+      }
+      return build('github_token', inputs, pat_fallback, 'explicit: github_token (degraded)');
     }
-    case 'disabled':
-      return disabled(inputs, 'auth explicitly disabled by request');
   }
 }
 
-function ok(
-  mode: Exclude<ResolvedAuth['auth_mode'], 'disabled'>,
-  user: string,
+function build(
+  selected: AuthMode,
   inputs: AuthResolverInputs,
-  degraded: boolean,
+  pat_fallback: boolean,
   reason: string
 ): ResolvedAuth {
-  const fetch_auth = fetchAuthFor(mode, inputs);
-  const write_auth = writeAuthFor(mode, inputs);
-  return {
-    auth_mode: mode,
-    star_source_user: user,
-    star_fetch_auth: fetch_auth,
-    repo_write_auth: write_auth,
-    degraded,
+  // CORE INVARIANT: every role is the selected_mode's credential class.
+  // No mixing is possible by construction. assertNoMixedAuth confirms.
+  const r: ResolvedAuth = {
+    requested_mode: inputs.requested_mode || 'auto',
+    selected_mode: selected,
+    star_fetch_auth: selected,
+    repo_write_auth: selected,
+    star_source_user: (inputs.star_source_user || '').trim(),
+    pat_fallback_to_github_token: selected === 'pat' ? pat_fallback : false,
+    degraded: selected === 'github_token',
     reason,
     missing_config: [],
-    capabilities: {
-      can_mint_app_token: mode === 'github_app' ? 'yes' : 'no',
-      // 'blocked' = required credential missing for the configured mode.
-      // 'no'      = mode does not provide this capability (e.g. github_token
-      //             cannot mint app tokens because that is structural).
-      can_fetch_star_page: fetch_auth.source === 'none' ? 'blocked' : 'yes',
-      can_checkout_target_repo: write_auth.source === 'none' ? 'blocked' : 'yes',
-    },
   };
-}
-
-function disabled(inputs: AuthResolverInputs, reason: string, missing_config: string[] = []): ResolvedAuth {
-  return {
-    auth_mode: 'disabled',
-    star_source_user: (inputs.star_source_user || '').trim(),
-    star_fetch_auth: NO_AUTH,
-    repo_write_auth: inputs.has_github_token ? { source: 'github_token' } : NO_AUTH,
-    degraded: true,
-    reason,
-    missing_config,
-    capabilities: {
-      can_mint_app_token: missing_config.length ? 'blocked' : 'no',
-      can_fetch_star_page: 'blocked',
-      can_checkout_target_repo: inputs.has_github_token ? 'yes' : 'blocked',
-    },
-  };
-}
-
-/**
- * Star fetch and repo write may use different sources.
- * github_app for repo write is preferred; star fetch under app mode
- * still needs a user-context token, so it falls through to PAT or public.
- */
-function fetchAuthFor(mode: Exclude<ResolvedAuth['auth_mode'], 'disabled'>, inputs: AuthResolverInputs): RoleAuth {
-  switch (mode) {
-    case 'github_app':
-      // App installation tokens cannot enumerate user.starredRepositories;
-      // need a user-context token. Prefer PAT; fall back to public if a user is set.
-      if (inputs.has_stars_token) return { source: 'pat' };
-      if (inputs.star_source_user) return { source: 'public' };
-      return NO_AUTH;
-    case 'pat':
-      return { source: 'pat' };
-    case 'public':
-      return { source: 'public' };
-    case 'github_token':
-      return { source: 'github_token' };
-  }
-}
-
-function writeAuthFor(mode: Exclude<ResolvedAuth['auth_mode'], 'disabled'>, inputs: AuthResolverInputs): RoleAuth {
-  switch (mode) {
-    case 'github_app':
-      return { source: 'github_app' };
-    case 'pat':
-      // PAT can write too; preferred over the workflow identity for commits.
-      return { source: 'pat' };
-    case 'public':
-      // Public-mode fetch still needs *something* to commit results back.
-      return inputs.has_github_token ? { source: 'github_token' } : NO_AUTH;
-    case 'github_token':
-      return { source: 'github_token' };
-  }
+  assertNoMixedAuth(r);
+  return r;
 }

--- a/src/auth/runtime-state.test.ts
+++ b/src/auth/runtime-state.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyRuntimeFailure, startEffective, type RuntimeContext } from './runtime-state.js';
+import type { ResolvedAuth } from './auth-mode.js';
+
+function resolved(selected: 'github_app' | 'pat' | 'github_token', pat_fallback = true): ResolvedAuth {
+  return {
+    requested_mode: 'auto',
+    selected_mode: selected,
+    star_fetch_auth: selected,
+    repo_write_auth: selected,
+    star_source_user: 'primeinc',
+    pat_fallback_to_github_token: selected === 'pat' ? pat_fallback : false,
+    degraded: selected === 'github_token',
+    reason: 'test',
+    missing_config: [],
+  };
+}
+
+describe('startEffective', () => {
+  it('initializes effective_mode === selected_mode and fallback_fired=false', () => {
+    const r = resolved('pat');
+    const e = startEffective(r);
+    expect(e.effective_mode).toBe('pat');
+    expect(e.fallback_fired).toBe(false);
+    expect(e.star_fetch_auth).toBe(e.repo_write_auth);
+  });
+});
+
+describe('applyRuntimeFailure — github_app', () => {
+  it('always re-throws (NEVER falls back, even if GITHUB_TOKEN available)', () => {
+    // Arrange
+    const e = startEffective(resolved('github_app'));
+    const ctx: RuntimeContext = { has_github_token_at_runtime: true, warn: vi.fn() };
+    const failure = { role: 'star_fetch' as const, attempted: 'github_app' as const, error: new Error('app failed') };
+    // Act + Assert
+    expect(() => applyRuntimeFailure(e, failure, ctx)).toThrow('app failed');
+    expect(ctx.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyRuntimeFailure — pat', () => {
+  it('falls back to github_token loudly when flag=true and GITHUB_TOKEN present', () => {
+    // Arrange
+    const e = startEffective(resolved('pat', true));
+    const warn = vi.fn();
+    const ctx: RuntimeContext = { has_github_token_at_runtime: true, warn };
+    const failure = { role: 'star_fetch' as const, attempted: 'pat' as const, error: new Error('Bad credentials') };
+    // Act
+    const next = applyRuntimeFailure(e, failure, ctx);
+    // Assert — fallback fired AND every role flipped (no mixing)
+    expect(next.fallback_fired).toBe(true);
+    expect(next.effective_mode).toBe('github_token');
+    expect(next.star_fetch_auth).toBe('github_token');
+    expect(next.repo_write_auth).toBe('github_token');
+    expect(next.degraded).toBe(true);
+    expect(next.selected_mode).toBe('pat'); // selected unchanged; effective is what changed
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('pat-mode runtime failure');
+    expect(warn.mock.calls[0][0]).toContain('transitioning effective_mode to github_token');
+  });
+
+  it('hard-fails when pat_fallback_to_github_token=false', () => {
+    const e = startEffective(resolved('pat', false));
+    const warn = vi.fn();
+    const ctx: RuntimeContext = { has_github_token_at_runtime: true, warn };
+    const failure = { role: 'star_fetch' as const, attempted: 'pat' as const, error: new Error('Bad credentials') };
+    expect(() => applyRuntimeFailure(e, failure, ctx)).toThrow('Bad credentials');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('hard-fails when GITHUB_TOKEN is not available at runtime', () => {
+    const e = startEffective(resolved('pat', true));
+    const ctx: RuntimeContext = { has_github_token_at_runtime: false };
+    const failure = { role: 'star_fetch' as const, attempted: 'pat' as const, error: new Error('Bad credentials') };
+    expect(() => applyRuntimeFailure(e, failure, ctx)).toThrow('Bad credentials');
+  });
+
+  it('only one fallback transition per run — second failure under github_token re-throws', () => {
+    const e0 = startEffective(resolved('pat', true));
+    const ctx: RuntimeContext = { has_github_token_at_runtime: true, warn: vi.fn() };
+    const e1 = applyRuntimeFailure(e0, { role: 'star_fetch', attempted: 'pat', error: new Error('first') }, ctx);
+    expect(e1.effective_mode).toBe('github_token');
+    expect(() =>
+      applyRuntimeFailure(e1, { role: 'repo_write', attempted: 'github_token', error: new Error('second') }, ctx)
+    ).toThrow('second');
+  });
+});
+
+describe('applyRuntimeFailure — github_token', () => {
+  it('always re-throws (no further fallback target)', () => {
+    const e = startEffective(resolved('github_token'));
+    const ctx: RuntimeContext = { has_github_token_at_runtime: true, warn: vi.fn() };
+    const failure = { role: 'repo_write' as const, attempted: 'github_token' as const, error: new Error('token failed') };
+    expect(() => applyRuntimeFailure(e, failure, ctx)).toThrow('token failed');
+  });
+});
+
+describe('summary invariant — no mixed-auth shape ever escapes the layer', () => {
+  it('after fallback, both star_fetch_auth and repo_write_auth match effective_mode', () => {
+    const e0 = startEffective(resolved('pat', true));
+    const ctx: RuntimeContext = { has_github_token_at_runtime: true, warn: vi.fn() };
+    const e1 = applyRuntimeFailure(e0, { role: 'star_fetch', attempted: 'pat', error: new Error('x') }, ctx);
+    expect(e1.star_fetch_auth).toBe(e1.effective_mode);
+    expect(e1.repo_write_auth).toBe(e1.effective_mode);
+  });
+});

--- a/src/auth/runtime-state.ts
+++ b/src/auth/runtime-state.ts
@@ -1,0 +1,104 @@
+// Runtime fallback transition layer.
+//
+// Per session-oracle verdict rule 6: fallback is represented as
+// effective_mode=github_token, NEVER as mixed role auth. This module
+// is the ONLY place a fallback transition happens, and it produces a
+// new EffectiveAuth where every role is the new credential class.
+//
+// Contract:
+//   - github_app failure  -> always re-throws. No fallback. Ever.
+//   - pat failure         -> if pat_fallback_to_github_token && a
+//                            GITHUB_TOKEN is available at runtime, returns
+//                            a new EffectiveAuth with effective_mode=
+//                            github_token (every role flipped). Loud
+//                            warning emitted via the supplied warn fn.
+//                            Else re-throws.
+//   - github_token failure -> always re-throws.
+//
+// The transition is OBSERVED — not hidden. The effective_mode field on
+// EffectiveAuth is what every workflow output and summary reads.
+
+import { assertNoMixedAuth, type EffectiveAuth, type ResolvedAuth } from './auth-mode.js';
+
+export type RuntimeFailure = {
+  /** Where the failure occurred ("star_fetch", "repo_write"). */
+  role: 'star_fetch' | 'repo_write';
+  /** What credential was attempted (matches selected_mode). */
+  attempted: ResolvedAuth['selected_mode'];
+  /** Underlying error. */
+  error: Error;
+};
+
+export type RuntimeContext = {
+  warn?: (msg: string) => void;
+  /** True iff GITHUB_TOKEN is available to act as fallback target. */
+  has_github_token_at_runtime: boolean;
+};
+
+/**
+ * Convert a config-time ResolvedAuth into the initial EffectiveAuth.
+ * No transition has fired yet, so effective_mode == selected_mode.
+ */
+export function startEffective(resolved: ResolvedAuth): EffectiveAuth {
+  const e: EffectiveAuth = {
+    ...resolved,
+    effective_mode: resolved.selected_mode,
+    fallback_fired: false,
+  };
+  assertNoMixedAuth(e);
+  return e;
+}
+
+/**
+ * Apply a runtime failure to an EffectiveAuth and decide:
+ *   - re-throw (hard fail), or
+ *   - return a new EffectiveAuth with effective_mode=github_token (loud).
+ *
+ * The returned EffectiveAuth has every role flipped to the new mode —
+ * never one-role-only.
+ */
+export function applyRuntimeFailure(
+  current: EffectiveAuth,
+  failure: RuntimeFailure,
+  ctx: RuntimeContext
+): EffectiveAuth {
+  // github_app: doctrine says NEVER fall back. Always hard-fail.
+  if (current.selected_mode === 'github_app') {
+    throw failure.error;
+  }
+
+  // github_token already in effect: nothing further to fall back to.
+  if (current.effective_mode === 'github_token') {
+    throw failure.error;
+  }
+
+  // pat mode: respect the fallback flag.
+  if (current.selected_mode === 'pat') {
+    if (!current.pat_fallback_to_github_token) {
+      throw failure.error;
+    }
+    if (!ctx.has_github_token_at_runtime) {
+      throw failure.error;
+    }
+    ctx.warn?.(
+      `pat-mode runtime failure on role=${failure.role} ` +
+        `(attempted=${failure.attempted}). pat_fallback_to_github_token=true ` +
+        `and GITHUB_TOKEN available; transitioning effective_mode to github_token. ` +
+        `Subsequent roles will use GITHUB_TOKEN identity.`
+    );
+    const next: EffectiveAuth = {
+      ...current,
+      effective_mode: 'github_token',
+      star_fetch_auth: 'github_token',
+      repo_write_auth: 'github_token',
+      degraded: true,
+      reason: `${current.reason} | runtime fallback: pat -> github_token (${failure.role})`,
+      fallback_fired: true,
+    };
+    assertNoMixedAuth(next);
+    return next;
+  }
+
+  // Should be unreachable, but defensive.
+  throw failure.error;
+}

--- a/src/auth/setup-doctor.ts
+++ b/src/auth/setup-doctor.ts
@@ -40,7 +40,10 @@ function readEnv(): Parameters<typeof resolveAuthMode>[0] {
     );
   }
   const fb = (process.env.PAT_FALLBACK_TO_GITHUB_TOKEN || 'true').trim().toLowerCase();
-  const appFetch = (process.env.GITHUB_APP_SUPPORTS_FETCH || 'false').trim().toLowerCase();
+  // Default true: the App-fetch REST path (src/fetch/list-paginator-rest.ts)
+  // is implemented. Set GITHUB_APP_SUPPORTS_FETCH=false to force auto to
+  // skip github_app while debugging.
+  const appFetch = (process.env.GITHUB_APP_SUPPORTS_FETCH || 'true').trim().toLowerCase();
   return {
     requested_mode: requested,
     star_source_user: process.env.STAR_SOURCE_USER || '',
@@ -49,7 +52,7 @@ function readEnv(): Parameters<typeof resolveAuthMode>[0] {
     has_stars_token: nonEmpty(process.env.STARS_TOKEN),
     has_github_token: nonEmpty(process.env.GITHUB_TOKEN),
     pat_fallback_to_github_token: fb !== 'false' && fb !== '0' && fb !== 'no',
-    github_app_supports_fetch: appFetch === 'true' || appFetch === '1' || appFetch === 'yes',
+    github_app_supports_fetch: appFetch !== 'false' && appFetch !== '0' && appFetch !== 'no',
   };
 }
 

--- a/src/auth/setup-doctor.ts
+++ b/src/auth/setup-doctor.ts
@@ -1,38 +1,46 @@
-// setup-doctor — prints the resolved auth matrix and writes typed outputs.
+// setup-doctor — resolves auth mode at config time, emits the strict shape.
 //
-// Run via `pnpm auth:doctor` or directly in a workflow step. Reads env:
-//   AUTH_MODE_REQUEST  (workflow input; default 'auto')
-//   STAR_SOURCE_USER   (vars.STAR_SOURCE_USER or default)
-//   GH_APP_CLIENT_ID   (vars; presence only)
-//   GH_APP_PRIVATE_KEY (secrets; presence only)
-//   STARS_TOKEN        (secrets; presence only)
-//   GITHUB_TOKEN       (built-in; presence only)
+// Per session-oracle verdict, the doctor outputs:
+//   - selected_mode (the credential class chosen at config time)
+//   - star_fetch_auth, repo_write_auth (always == selected_mode; no mixing)
+//   - pat_fallback_to_github_token (bool; only meaningful for pat mode)
+//   - degraded (true iff selected_mode == github_token)
+//   - reason
 //
-// Writes to:
-//   stdout       — JSON resolution (one line)
-//   $GITHUB_STEP_SUMMARY — markdown matrix (presence/status, never values)
-//   $GITHUB_OUTPUT       — auth_mode, star_source_user, star_fetch_auth,
-//                          repo_write_auth, degraded, missing_config (joined)
+// The runtime fallback transition (effective_mode flipping from pat to
+// github_token on a runtime credential failure) happens INSIDE the
+// fetch/sync CLIs and is reported by THEM, not here. The doctor only
+// reports the config-time selection.
 //
-// Exits non-zero only when auth_mode === 'disabled' AND the doctor was
-// invoked with --strict. Without --strict, a disabled mode is reported
-// but the workflow keeps running so 02-Sync can still produce
-// downstream-readable diagnostics.
+// Reads env (presence only, never values printed):
+//   AUTH_MODE_REQUEST                 (workflow input; default 'auto')
+//   STAR_SOURCE_USER                  (vars; default empty)
+//   GH_APP_CLIENT_ID                  (vars)
+//   GH_APP_PRIVATE_KEY                (secret)
+//   STARS_TOKEN                       (secret)
+//   GITHUB_TOKEN                      (built-in)
+//   PAT_FALLBACK_TO_GITHUB_TOKEN      (workflow input; default 'true')
 
 import { appendFileSync, existsSync } from 'node:fs';
 import process from 'node:process';
-import { resolveAuthMode } from './resolve-auth-mode.js';
-import type { AuthMode, ResolvedAuth } from './auth-mode.js';
+import { AuthConfigError, resolveAuthMode } from './resolve-auth-mode.js';
+import { AUTH_MODES, type AuthMode, type ResolvedAuth } from './auth-mode.js';
 
-const VALID_MODES: ReadonlyArray<AuthMode | 'auto'> = [
-  'auto', 'github_app', 'pat', 'public', 'github_token', 'disabled',
-];
+const VALID_REQUEST_MODES: ReadonlyArray<AuthMode | 'auto'> = ['auto', ...AUTH_MODES];
+
+function nonEmpty(v: string | undefined): boolean {
+  return typeof v === 'string' && v.trim().length > 0;
+}
 
 function readEnv(): Parameters<typeof resolveAuthMode>[0] {
   const requested = (process.env.AUTH_MODE_REQUEST || 'auto').trim() as AuthMode | 'auto';
-  if (!VALID_MODES.includes(requested)) {
-    throw new Error(`AUTH_MODE_REQUEST=${requested} is not one of: ${VALID_MODES.join(', ')}`);
+  if (!VALID_REQUEST_MODES.includes(requested)) {
+    throw new Error(
+      `AUTH_MODE_REQUEST=${requested} is not one of: ${VALID_REQUEST_MODES.join(', ')}`
+    );
   }
+  const fb = (process.env.PAT_FALLBACK_TO_GITHUB_TOKEN || 'true').trim().toLowerCase();
+  const appFetch = (process.env.GITHUB_APP_SUPPORTS_FETCH || 'false').trim().toLowerCase();
   return {
     requested_mode: requested,
     star_source_user: process.env.STAR_SOURCE_USER || '',
@@ -40,33 +48,34 @@ function readEnv(): Parameters<typeof resolveAuthMode>[0] {
     has_gh_app_private_key: nonEmpty(process.env.GH_APP_PRIVATE_KEY),
     has_stars_token: nonEmpty(process.env.STARS_TOKEN),
     has_github_token: nonEmpty(process.env.GITHUB_TOKEN),
+    pat_fallback_to_github_token: fb !== 'false' && fb !== '0' && fb !== 'no',
+    github_app_supports_fetch: appFetch === 'true' || appFetch === '1' || appFetch === 'yes',
   };
-}
-
-function nonEmpty(v: string | undefined): boolean {
-  return typeof v === 'string' && v.trim().length > 0;
 }
 
 export function renderSummary(r: ResolvedAuth): string {
   const lines: string[] = [];
   lines.push('## Auth setup-doctor');
   lines.push('');
-  lines.push(`- **Auth mode**: \`${r.auth_mode}\`${r.degraded ? ' _(degraded)_' : ''}`);
+  lines.push(`- **Selected mode**: \`${r.selected_mode}\`${r.degraded ? ' _(degraded)_' : ''}`);
+  lines.push(`- **Requested**: \`${r.requested_mode}\``);
   lines.push(`- **Star source user**: \`${r.star_source_user || '(unset)'}\``);
-  lines.push(`- **Star fetch auth**: \`${r.star_fetch_auth.source}\``);
-  lines.push(`- **Repo write auth**: \`${r.repo_write_auth.source}\``);
+  lines.push(`- **star_fetch_auth**: \`${r.star_fetch_auth}\``);
+  lines.push(`- **repo_write_auth**: \`${r.repo_write_auth}\``);
   lines.push(`- **Reason**: ${r.reason}`);
-  if (r.missing_config.length) {
-    lines.push(`- **Missing**: ${r.missing_config.map(m => `\`${m}\``).join(', ')}`);
+  if (r.selected_mode === 'pat') {
+    lines.push(
+      `- **pat_fallback_to_github_token**: \`${r.pat_fallback_to_github_token}\` ` +
+        `_(if PAT fails at runtime, ${r.pat_fallback_to_github_token ? 'transition effective_mode to github_token' : 'hard-fail'})_`
+    );
   }
   lines.push('');
-  lines.push('### Capability matrix');
-  lines.push('');
-  lines.push('| Capability | Status |');
-  lines.push('|---|---|');
-  lines.push(`| Mint GitHub App installation token | \`${r.capabilities.can_mint_app_token}\` |`);
-  lines.push(`| Fetch a star page              | \`${r.capabilities.can_fetch_star_page}\` |`);
-  lines.push(`| Checkout / commit to target repo | \`${r.capabilities.can_checkout_target_repo}\` |`);
+  lines.push('### Doctrine');
+  lines.push('- Selected mode owns every role. star_fetch_auth and repo_write_auth must equal selected_mode.');
+  lines.push('- `github_app` failure at runtime → hard-fail. NEVER falls back.');
+  lines.push('- `pat` failure at runtime → loud transition to `effective_mode=github_token` if `pat_fallback_to_github_token=true`, else hard-fail.');
+  lines.push('- `github_token` failure → hard-fail.');
+  lines.push('- Fallback is reported as `effective_mode`, never as a mixed role-by-role auth.');
   lines.push('');
   return lines.join('\n');
 }
@@ -74,13 +83,16 @@ export function renderSummary(r: ResolvedAuth): string {
 export function writeJobOutputs(r: ResolvedAuth): void {
   const out = process.env.GITHUB_OUTPUT;
   if (!out) return;
+  // NOTE: per verdict rule 7, star_fetch_auth and repo_write_auth ALWAYS
+  // equal selected_mode at config time. The CI gate validates this shape.
   const lines = [
-    `auth_mode=${r.auth_mode}`,
+    `selected_mode=${r.selected_mode}`,
+    `requested_mode=${r.requested_mode}`,
     `star_source_user=${r.star_source_user}`,
-    `star_fetch_auth=${r.star_fetch_auth.source}`,
-    `repo_write_auth=${r.repo_write_auth.source}`,
+    `star_fetch_auth=${r.star_fetch_auth}`,
+    `repo_write_auth=${r.repo_write_auth}`,
     `degraded=${r.degraded}`,
-    `missing_config=${r.missing_config.join(',')}`,
+    `pat_fallback_to_github_token=${r.pat_fallback_to_github_token}`,
     `reason=${oneLine(r.reason)}`,
   ];
   appendFileSync(out, lines.join('\n') + '\n');
@@ -100,18 +112,45 @@ function oneLine(s: string): string {
 function main(): void {
   const strict = process.argv.includes('--strict');
   const inputs = readEnv();
-  const r = resolveAuthMode(inputs);
 
-  // Always emit JSON to stdout for programmatic consumers.
+  let r: ResolvedAuth;
+  try {
+    r = resolveAuthMode(inputs);
+  } catch (err) {
+    if (err instanceof AuthConfigError) {
+      process.stderr.write(`::error::${err.message}\n`);
+      process.stderr.write(`Missing config: ${err.missing_config.join(', ')}\n`);
+      // Even on config error, write a minimal output so downstream steps
+      // can branch on a 'failed' marker rather than crashing.
+      const out = process.env.GITHUB_OUTPUT;
+      if (out) {
+        appendFileSync(
+          out,
+          [
+            'selected_mode=',
+            'requested_mode=' + (inputs.requested_mode || 'auto'),
+            'star_source_user=' + (inputs.star_source_user || ''),
+            'star_fetch_auth=',
+            'repo_write_auth=',
+            'degraded=true',
+            'pat_fallback_to_github_token=false',
+            'reason=' + oneLine(err.message),
+            'config_error=true',
+            'missing_config=' + err.missing_config.join(','),
+          ].join('\n') + '\n'
+        );
+      }
+      writeSummary(`## Auth setup-doctor — CONFIG ERROR\n\n- ${err.message}\n- Missing: ${err.missing_config.join(', ')}\n`);
+      process.exit(1);
+    }
+    throw err;
+  }
+
   process.stdout.write(JSON.stringify(r, null, 2) + '\n');
-
-  // Markdown summary for humans reading the run page.
   writeSummary(renderSummary(r));
-
-  // Structured outputs for downstream workflow steps.
   writeJobOutputs(r);
 
-  if (r.auth_mode === 'disabled' && strict) {
+  if (r.degraded && strict) {
     process.exitCode = 1;
   }
 }

--- a/src/fetch/cli.ts
+++ b/src/fetch/cli.ts
@@ -2,20 +2,26 @@
 // fetch step. Replaces the prior actions/github-script JS blob.
 //
 // Reads env (no positional args):
-//   GH_TOKEN              token for star-fetch (required)
-//   RESUME_CURSOR         optional resume cursor (workflow_dispatch input)
-//   LIST_QUERY_PATH       default queries/stars-list-query.graphql
+//   GH_TOKEN               token for star-fetch (required)
+//   SELECTED_MODE          'github_app' | 'pat' | 'github_token' (required;
+//                          forwarded from setup-doctor.outputs.selected_mode)
+//   STAR_SOURCE_USER       required when SELECTED_MODE=github_app
+//                          (REST /users/{username}/starred takes a username;
+//                          installation tokens have no user context)
+//   RESUME_CURSOR          optional resume token (opaque format depends on mode)
+//   LIST_QUERY_PATH        default queries/stars-list-query.graphql
+//                          (only used in pat / github_token modes)
 //   METADATA_FRAGMENT_PATH default queries/stars-metadata-fragment.graphql
-//   OUTPUT_FILE           default .github-stars/data/fetched-stars-graphql.json
-//   METADATA_BATCH_SIZE   default 25
+//   OUTPUT_FILE            default .github-stars/data/fetched-stars-graphql.json
+//   METADATA_BATCH_SIZE    default 25
 //
 // Writes:
-//   OUTPUT_FILE  — JSON array of FetchedRepo
-//   $GITHUB_OUTPUT — total_repos, archived_count, fork_count,
-//                    no_description_count, output_file, output_bytes,
-//                    partial_failure_reason, resume_cursor, pages_fetched,
-//                    batches_fetched, blocked_orgs (csv)
-//   stderr  — info/warning lines for the runner log
+//   OUTPUT_FILE     — JSON array of FetchedRepo
+//   $GITHUB_OUTPUT  — total_repos, archived_count, fork_count,
+//                     no_description_count, output_file, output_bytes,
+//                     partial_failure_reason, resume_cursor, pages_fetched,
+//                     batches_fetched, blocked_orgs_count
+//   stderr          — info/warning lines for the runner log
 
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync, appendFileSync } from 'node:fs';
 import { dirname } from 'node:path';
@@ -42,19 +48,45 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  const selectedModeRaw = (process.env.SELECTED_MODE || '').trim();
+  if (!['github_app', 'pat', 'github_token'].includes(selectedModeRaw)) {
+    console.error(
+      `SELECTED_MODE must be one of: github_app, pat, github_token. ` +
+        `Got: '${selectedModeRaw}'. Forward from setup-doctor.outputs.selected_mode.`
+    );
+    process.exit(2);
+  }
+  const selectedMode = selectedModeRaw as 'github_app' | 'pat' | 'github_token';
+
+  const starSourceUser = (process.env.STAR_SOURCE_USER || '').trim();
+  if (selectedMode === 'github_app' && !starSourceUser) {
+    console.error(
+      'STAR_SOURCE_USER env required when SELECTED_MODE=github_app ' +
+        '(REST /users/{username}/starred path needs a username; installation tokens have no user context).'
+    );
+    process.exit(2);
+  }
+
   const LIST_QUERY_PATH = envOrDefault('LIST_QUERY_PATH', 'queries/stars-list-query.graphql');
   const FRAGMENT_PATH = envOrDefault('METADATA_FRAGMENT_PATH', 'queries/stars-metadata-fragment.graphql');
   const OUTPUT_FILE = envOrDefault('OUTPUT_FILE', '.github-stars/data/fetched-stars-graphql.json');
   const BATCH_SIZE = parseInt(envOrDefault('METADATA_BATCH_SIZE', String(DEFAULT_METADATA_BATCH_SIZE)), 10);
   const resumeCursor = (process.env.RESUME_CURSOR || '').trim() || null;
 
-  for (const p of [LIST_QUERY_PATH, FRAGMENT_PATH]) {
-    if (!existsSync(p)) {
-      console.error(`Required query file not found: ${p}`);
+  // Stage 1 query is only needed in pat/github_token modes; github_app
+  // uses REST. Fragment is needed in ALL modes (stage 2 is GraphQL).
+  if (!existsSync(FRAGMENT_PATH)) {
+    console.error(`Required query file not found: ${FRAGMENT_PATH}`);
+    process.exit(2);
+  }
+  let listQuery = '';
+  if (selectedMode !== 'github_app') {
+    if (!existsSync(LIST_QUERY_PATH)) {
+      console.error(`Required query file not found: ${LIST_QUERY_PATH}`);
       process.exit(2);
     }
+    listQuery = readFileSync(LIST_QUERY_PATH, 'utf8');
   }
-  const listQuery = readFileSync(LIST_QUERY_PATH, 'utf8');
   const metadataFragment = readFileSync(FRAGMENT_PATH, 'utf8');
 
   const octokit = createOctokit({ token, retries: 5 });
@@ -64,6 +96,8 @@ async function main(): Promise<void> {
 
   const result = await fetchStars({
     octokit,
+    selectedMode,
+    starSourceUser,
     listQuery,
     metadataFragment,
     resumeCursor,

--- a/src/fetch/cli.ts
+++ b/src/fetch/cli.ts
@@ -94,7 +94,8 @@ async function main(): Promise<void> {
   setOutput(`pages_fetched=${result.pageCount}`);
   setOutput(`batches_fetched=${result.batchCount}`);
   setOutput(`resume_cursor=${result.lastEndCursor ?? ''}`);
-  setOutput(`blocked_orgs=${result.inaccessibleOrgs.join(',')}`);
+  // Per session-oracle verdict rule 8: count only, not names.
+  setOutput(`blocked_orgs_count=${result.blockedOrgsCount}`);
 
   if (result.partialFailureReason) {
     console.error(

--- a/src/fetch/fetch-stars.ts
+++ b/src/fetch/fetch-stars.ts
@@ -34,16 +34,19 @@ export async function fetchStars(opts: FetchStarsOptions): Promise<FetchOutcome>
       pageCount: stage1.pageCount,
       batchCount: 0,
       lastEndCursor: stage1.lastEndCursor,
-      inaccessibleOrgs: [...stage1.inaccessibleOrgs].sort(),
+      blockedOrgsCount: stage1.inaccessibleOrgs.size,
       partialFailureReason: stage1.partialFailureReason,
     };
   }
 
   log(`Stage 1 done: ${stage1.list.length} public stars across ${stage1.pageCount} pages.`);
   if (stage1.inaccessibleOrgs.size > 0) {
+    // Per session-oracle verdict rule 8: do NOT print blocked org NAMES
+    // in public workflow logs. Names are private/internal source identifiers
+    // for the user's stars and may be sensitive. Count is fine.
     warn(
-      `Skipped ${stage1.inaccessibleOrgs.size} orgs that block classic-PAT access: ` +
-        `${[...stage1.inaccessibleOrgs].sort().join(', ')}. ` +
+      `Skipped ${stage1.inaccessibleOrgs.size} org(s) that block classic-PAT access ` +
+        `(names redacted from public log). ` +
         `To include them, switch to a fine-grained PAT or GitHub App.`
     );
   }
@@ -81,7 +84,7 @@ export async function fetchStars(opts: FetchStarsOptions): Promise<FetchOutcome>
     pageCount: stage1.pageCount,
     batchCount: stage2.batchCount,
     lastEndCursor: stage1.lastEndCursor,
-    inaccessibleOrgs: [...blocked].sort(),
+    blockedOrgsCount: blocked.size,
     partialFailureReason,
   };
 }

--- a/src/fetch/fetch-stars.ts
+++ b/src/fetch/fetch-stars.ts
@@ -1,14 +1,53 @@
 // Orchestrates list pagination + metadata batches.
+//
+// Stage 1 (list-only) has TWO implementations chosen by selected_mode:
+//
+//   pat / github_token mode -> GraphQL `viewer.starredRepositories`
+//                              (list-paginator.ts). Uses user-context auth;
+//                              works because PAT and GITHUB_TOKEN both
+//                              carry user identity.
+//
+//   github_app mode         -> REST `/users/{username}/starred`
+//                              (list-paginator-rest.ts). Required because
+//                              App installation tokens have no user context;
+//                              first-party progAccess docs confirm
+//                              `viewer.starredRepositories` is
+//                              serverToServer:false but
+//                              `/users/:username/starred` is
+//                              serverToServer:true.
+//                              See list-paginator-rest.ts header for citations.
+//
+// Stage 2 (per-repo metadata) is GraphQL aliased batches in BOTH modes —
+// `repository(owner, name)` is serverToServer:true so installation tokens
+// work fine.
+//
+// This is the ONLY place mode-specific code lives. Both downstream stages
+// see the same StarListEntry[] shape regardless of which paginator ran.
 
 import { paginateStarList } from './list-paginator.js';
+import { paginateStarListViaRest, parseRestResumeToken } from './list-paginator-rest.js';
 import { fetchMetadataInBatches, DEFAULT_METADATA_BATCH_SIZE } from './metadata-batcher.js';
 import type { OctokitClient } from './octokit-client.js';
 import type { FetchOutcome } from './types.js';
 
+export type SelectedMode = 'github_app' | 'pat' | 'github_token';
+
 export type FetchStarsOptions = {
   octokit: OctokitClient;
+  /** Drives which stage-1 implementation runs. */
+  selectedMode: SelectedMode;
+  /** Required when selectedMode === 'github_app' (REST endpoint takes a username). */
+  starSourceUser: string;
+  /** GraphQL list query (used by pat/github_token modes). */
   listQuery: string;
+  /** GraphQL fragment (used by stage 2 in ALL modes). */
   metadataFragment: string;
+  /**
+   * Resume token. Opaque to the caller:
+   *   - pat/github_token modes: GraphQL endCursor string
+   *   - github_app mode: REST page number as string
+   * Each paginator interprets its own format.
+   */
   resumeCursor: string | null;
   batchSize?: number;
   log?: (msg: string) => void;
@@ -19,35 +58,68 @@ export async function fetchStars(opts: FetchStarsOptions): Promise<FetchOutcome>
   const log = opts.log ?? (() => {});
   const warn = opts.warn ?? (() => {});
 
-  log('Stage 1: paginating star list (cheap query)...');
-  const stage1 = await paginateStarList({
-    octokit: opts.octokit,
-    query: opts.listQuery,
-    resumeCursor: opts.resumeCursor,
-    log,
-    warn,
-  });
+  log(`Stage 1: paginating star list (mode=${opts.selectedMode})...`);
 
-  if (stage1.partialFailureReason) {
+  // Stage 1: branch on selected_mode. The "no mixed auth" doctrine is
+  // honored because both branches use opts.octokit, which the workflow
+  // built from selected_mode's credential. The branch picks an ENDPOINT,
+  // not a credential.
+  let stage1List: Array<{ repo: string; user_starred_at: string }>;
+  let stage1PageCount: number;
+  let stage1ResumeToken: string | null;
+  let stage1BlockedOrgs: Set<string>;
+  let stage1PartialFailure: string;
+
+  if (opts.selectedMode === 'github_app') {
+    if (!opts.starSourceUser) {
+      throw new Error('github_app mode requires starSourceUser (REST /users/{username}/starred path needs a username)');
+    }
+    const r = await paginateStarListViaRest({
+      octokit: opts.octokit,
+      username: opts.starSourceUser,
+      startPage: parseRestResumeToken(opts.resumeCursor),
+      log,
+      warn,
+    });
+    stage1List = r.list;
+    stage1PageCount = r.pageCount;
+    stage1ResumeToken = r.resumeToken;
+    stage1BlockedOrgs = r.inaccessibleOrgs;
+    stage1PartialFailure = r.partialFailureReason;
+  } else {
+    const r = await paginateStarList({
+      octokit: opts.octokit,
+      query: opts.listQuery,
+      resumeCursor: opts.resumeCursor,
+      log,
+      warn,
+    });
+    stage1List = r.list;
+    stage1PageCount = r.pageCount;
+    stage1ResumeToken = r.lastEndCursor;
+    stage1BlockedOrgs = r.inaccessibleOrgs;
+    stage1PartialFailure = r.partialFailureReason;
+  }
+
+  if (stage1PartialFailure) {
     return {
       repos: [],
-      pageCount: stage1.pageCount,
+      pageCount: stage1PageCount,
       batchCount: 0,
-      lastEndCursor: stage1.lastEndCursor,
-      blockedOrgsCount: stage1.inaccessibleOrgs.size,
-      partialFailureReason: stage1.partialFailureReason,
+      lastEndCursor: stage1ResumeToken,
+      blockedOrgsCount: stage1BlockedOrgs.size,
+      partialFailureReason: stage1PartialFailure,
     };
   }
 
-  log(`Stage 1 done: ${stage1.list.length} public stars across ${stage1.pageCount} pages.`);
-  if (stage1.inaccessibleOrgs.size > 0) {
+  log(`Stage 1 done: ${stage1List.length} public stars across ${stage1PageCount} pages.`);
+  if (stage1BlockedOrgs.size > 0) {
     // Per session-oracle verdict rule 8: do NOT print blocked org NAMES
     // in public workflow logs. Names are private/internal source identifiers
     // for the user's stars and may be sensitive. Count is fine.
     warn(
-      `Skipped ${stage1.inaccessibleOrgs.size} org(s) that block classic-PAT access ` +
-        `(names redacted from public log). ` +
-        `To include them, switch to a fine-grained PAT or GitHub App.`
+      `Skipped ${stage1BlockedOrgs.size} org(s) that block classic-PAT access ` +
+        `(names redacted from public log).`
     );
   }
 
@@ -55,24 +127,21 @@ export async function fetchStars(opts: FetchStarsOptions): Promise<FetchOutcome>
   const stage2 = await fetchMetadataInBatches({
     octokit: opts.octokit,
     fragment: opts.metadataFragment,
-    list: stage1.list,
+    list: stage1List,
     batchSize: opts.batchSize,
     log,
     warn,
   });
 
-  // Combine blocked-org sets across stages.
-  const blocked = new Set<string>([...stage1.inaccessibleOrgs, ...stage2.blockedOrgs]);
+  const blocked = new Set<string>([...stage1BlockedOrgs, ...stage2.blockedOrgs]);
 
-  // Tolerance: if stage2 left repos unfetched, only treat as success when the
-  // gap matches the count of skipped blocked-org repos (≤10% tolerance).
   let partialFailureReason = stage2.partialFailureReason;
-  const gap = stage1.list.length - stage2.repos.length;
+  const gap = stage1List.length - stage2.repos.length;
   if (!partialFailureReason && gap > 0) {
-    if (blocked.size > 0 && gap < stage1.list.length * 0.1) {
+    if (blocked.size > 0 && gap < stage1List.length * 0.1) {
       log(`Stage 2 expected gap: ${gap} repos in classic-PAT-blocked orgs (${blocked.size} orgs).`);
     } else {
-      partialFailureReason = `metadata_incomplete_${stage2.repos.length}_of_${stage1.list.length}_gap=${gap}`;
+      partialFailureReason = `metadata_incomplete_${stage2.repos.length}_of_${stage1List.length}_gap=${gap}`;
       warn(
         `Stage 2 left ${gap} repos unfetched, more than the ${blocked.size} blocked orgs explain.`
       );
@@ -81,9 +150,9 @@ export async function fetchStars(opts: FetchStarsOptions): Promise<FetchOutcome>
 
   return {
     repos: stage2.repos,
-    pageCount: stage1.pageCount,
+    pageCount: stage1PageCount,
     batchCount: stage2.batchCount,
-    lastEndCursor: stage1.lastEndCursor,
+    lastEndCursor: stage1ResumeToken,
     blockedOrgsCount: blocked.size,
     partialFailureReason,
   };

--- a/src/fetch/list-paginator-rest.test.ts
+++ b/src/fetch/list-paginator-rest.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import { paginateStarListViaRest, parseRestResumeToken } from './list-paginator-rest.js';
+
+function fakeOctokit(pages: Array<unknown>) {
+  let i = 0;
+  return {
+    request: vi.fn(async (route: string, params: Record<string, unknown>) => {
+      const p = pages[i++];
+      if (p instanceof Error) throw p;
+      return { data: p, status: 200, url: route, headers: {} };
+    }),
+  } as unknown as Parameters<typeof paginateStarListViaRest>[0]['octokit'];
+}
+
+describe('paginateStarListViaRest', () => {
+  it('walks pages until a partial-fill page (REST has no cursor) and excludes private repos', async () => {
+    // Arrange: page 1 full (per_page=2 fake), page 2 partial → end.
+    const oct = fakeOctokit([
+      [
+        { starred_at: '2025-01-01T00:00:00Z', repo: { full_name: 'a/b', private: false } },
+        { starred_at: '2025-01-02T00:00:00Z', repo: { full_name: 'c/d', private: true } },
+      ],
+      [
+        { starred_at: '2025-01-03T00:00:00Z', repo: { full_name: 'e/f', private: false } },
+      ],
+    ]);
+    // Act
+    const r = await paginateStarListViaRest({ octokit: oct, username: 'primeinc', perPage: 2 });
+    // Assert
+    expect(r.pageCount).toBe(2);
+    expect(r.list).toEqual([
+      { repo: 'a/b', user_starred_at: '2025-01-01T00:00:00Z' },
+      { repo: 'e/f', user_starred_at: '2025-01-03T00:00:00Z' },
+    ]);
+    expect(r.partialFailureReason).toBe('');
+    expect(r.resumeToken).toBeNull();
+  });
+
+  it('passes the star+json Accept header (needed for starred_at field)', async () => {
+    const oct = fakeOctokit([[]]);
+    await paginateStarListViaRest({ octokit: oct, username: 'primeinc', perPage: 2 });
+    expect(oct.request).toHaveBeenCalledWith(
+      'GET /users/{username}/starred',
+      expect.objectContaining({
+        username: 'primeinc',
+        per_page: 2,
+        page: 1,
+        headers: { accept: 'application/vnd.github.star+json' },
+      })
+    );
+  });
+
+  it('hard-fails with a usable resume token when a request errors', async () => {
+    const err = Object.assign(new Error('502 Bad Gateway'), { status: 502 });
+    const oct = fakeOctokit([
+      [{ starred_at: '2025-01-01T00:00:00Z', repo: { full_name: 'a/b', private: false } }],
+      err,
+    ]);
+    const r = await paginateStarListViaRest({ octokit: oct, username: 'primeinc', perPage: 1 });
+    expect(r.partialFailureReason).toContain('rest_list_error_at_page_2');
+    expect(r.partialFailureReason).toContain('status=502');
+    expect(r.resumeToken).toBe('2');
+    expect(r.list).toHaveLength(1);
+  });
+
+  it('startPage is honored for resume', async () => {
+    const oct = fakeOctokit([[]]);
+    await paginateStarListViaRest({ octokit: oct, username: 'primeinc', startPage: 7, perPage: 100 });
+    expect(oct.request).toHaveBeenCalledWith(
+      'GET /users/{username}/starred',
+      expect.objectContaining({ page: 7 })
+    );
+  });
+
+  it('treats invalid (non-array) response shape as a hard failure', async () => {
+    const oct = fakeOctokit([{ message: 'something else' }]);
+    const r = await paginateStarListViaRest({ octokit: oct, username: 'primeinc', perPage: 100 });
+    expect(r.partialFailureReason).toContain('rest_list_invalid_response');
+  });
+});
+
+describe('parseRestResumeToken', () => {
+  it('null and empty string return 1 (start page)', () => {
+    expect(parseRestResumeToken(null)).toBe(1);
+    expect(parseRestResumeToken('')).toBe(1);
+  });
+  it('valid integer string returns the integer', () => {
+    expect(parseRestResumeToken('5')).toBe(5);
+  });
+  it('garbage returns 1 (defensive)', () => {
+    expect(parseRestResumeToken('abc')).toBe(1);
+    expect(parseRestResumeToken('-3')).toBe(1);
+  });
+});

--- a/src/fetch/list-paginator-rest.ts
+++ b/src/fetch/list-paginator-rest.ts
@@ -1,0 +1,163 @@
+// Stage 1 (App-mode): REST `GET /users/{username}/starred` paginator.
+//
+// Why REST instead of the GraphQL paginator used by pat-mode?
+//
+// First-party evidence from refs/github/docs/src/rest/data/fpt-2026-03-10/
+// activity.json:
+//
+//   GET /user/starred (the AUTHENTICATED-user form):
+//     progAccess.serverToServer = false   <- App installation token CANNOT call
+//     progAccess.userToServerRest = true  <- needs OAuth user-to-server
+//
+//   GET /users/{username}/starred (the SPECIFIC-user form):
+//     progAccess.serverToServer = true    <- App installation token CAN call
+//     progAccess.userToServerRest = true
+//     progAccess.allowsPublicRead = true
+//
+// GraphQL `viewer.starredRepositories` is the "authenticated user" shape
+// (same boundary as `/user/starred`); App installation tokens have no
+// user context, so the GraphQL path returns INSUFFICIENT_SCOPES. The
+// `/users/{username}/starred` endpoint is `serverToServer: true` and
+// the App installation token authenticates it cleanly. That's why
+// github_app mode uses REST for stage 1, while pat mode keeps GraphQL.
+//
+// Stage 2 (per-repo metadata) stays GraphQL in BOTH modes because
+// `repository(owner, name)` IS `serverToServer: true` (App installation
+// tokens can read it).
+//
+// Custom Accept header `application/vnd.github.star+json` makes the
+// response shape `[{ starred_at, repo: {...} }]` instead of the default
+// `[ {repo fields directly} ]`. We need starred_at to populate
+// StarListEntry.user_starred_at — same field 02-sync's reconcile reads.
+
+import type { OctokitClient } from './octokit-client.js';
+import type { StarListEntry } from './types.js';
+import { errorMessage, errorStatus, isBadCredentials } from './partial-graphql.js';
+import { BAD_CREDENTIALS_ERROR } from './list-paginator.js';
+
+export type RestStarItem = {
+  starred_at: string;
+  repo: { full_name: string; private: boolean };
+};
+
+export type RestPaginationOutcome = {
+  list: StarListEntry[];
+  pageCount: number;
+  /**
+   * REST pagination uses page numbers, not opaque cursors. We surface
+   * the next page number on partial failure so the workflow can resume.
+   * The doctor/workflow exposes this in the same `resume_cursor` slot
+   * for symmetry with the GraphQL paginator; the consumer treats it as
+   * an opaque token.
+   */
+  resumeToken: string | null;
+  /**
+   * Per session-oracle verdict rule 8: count only, no names. The REST
+   * endpoint does not surface "this org blocks classic-PAT" errors the
+   * way GraphQL does (App installation tokens hit a different access
+   * control surface), so this is essentially always 0 under App mode.
+   * Kept for shape parity with the GraphQL paginator.
+   */
+  inaccessibleOrgs: Set<string>;
+  partialFailureReason: string;
+};
+
+export type RestPaginationOptions = {
+  octokit: OctokitClient;
+  username: string;
+  /** REST page number to start from (1-based). Default: 1. */
+  startPage?: number;
+  /** per_page, max 100 per docs. Default: 100. */
+  perPage?: number;
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+};
+
+const DEFAULT_PER_PAGE = 100;
+
+export async function paginateStarListViaRest(opts: RestPaginationOptions): Promise<RestPaginationOutcome> {
+  const log = opts.log ?? (() => {});
+  const warn = opts.warn ?? (() => {});
+  const perPage = opts.perPage ?? DEFAULT_PER_PAGE;
+  const startPage = opts.startPage ?? 1;
+
+  const list: StarListEntry[] = [];
+  const inaccessibleOrgs = new Set<string>();
+  let pageCount = 0;
+  let page = startPage;
+  let partialFailureReason = '';
+  let lastSucceededPage = startPage - 1;
+
+  // Loop until a page returns fewer than perPage items (last page) or
+  // an empty array (past last page). REST gives no cursor — we count.
+  while (true) {
+    pageCount++;
+    let items: RestStarItem[] | null = null;
+
+    try {
+      const res = await opts.octokit.request('GET /users/{username}/starred', {
+        username: opts.username,
+        per_page: perPage,
+        page,
+        // Custom media type per refs/github/docs/.../activity.json:91868:
+        // "application/vnd.github.star+json: Includes a timestamp of when
+        // the star was created."
+        headers: { accept: 'application/vnd.github.star+json' },
+      });
+      items = (res.data as unknown) as RestStarItem[];
+    } catch (error: unknown) {
+      if (isBadCredentials(error)) {
+        partialFailureReason = `bad_credentials_at_page_${pageCount}`;
+        warn(BAD_CREDENTIALS_ERROR);
+        break;
+      }
+      partialFailureReason =
+        `rest_list_error_at_page_${page}_after_${list.length}_repos_status=${errorStatus(error)}_msg=${errorMessage(error)}`;
+      warn(
+        `Stage 1 REST list failed at page ${page}: ${errorMessage(error)}. ` +
+          `Resume from page=${page} on retry.`
+      );
+      break;
+    }
+
+    if (!Array.isArray(items)) {
+      partialFailureReason =
+        `rest_list_invalid_response_at_page_${page}_type=${typeof items}`;
+      warn(`Stage 1 REST list returned non-array at page ${page}.`);
+      break;
+    }
+
+    for (const item of items) {
+      if (item?.repo && !item.repo.private && typeof item.repo.full_name === 'string') {
+        list.push({ repo: item.repo.full_name, user_starred_at: item.starred_at });
+      }
+    }
+
+    lastSucceededPage = page;
+
+    if (pageCount % 5 === 0) {
+      log(`  list page ${pageCount} (REST page=${page}): total=${list.length}`);
+    }
+
+    if (items.length < perPage) {
+      // Last page (partial fill or empty == done).
+      break;
+    }
+    page++;
+  }
+
+  return {
+    list,
+    pageCount,
+    resumeToken: partialFailureReason ? String(page) : null,
+    inaccessibleOrgs,
+    partialFailureReason,
+  };
+}
+
+/** Resume token is a page number string for REST; opaque to consumers. */
+export function parseRestResumeToken(token: string | null): number {
+  if (!token) return 1;
+  const n = parseInt(token, 10);
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+}

--- a/src/fetch/types.ts
+++ b/src/fetch/types.ts
@@ -33,8 +33,14 @@ export type FetchOutcome = {
   pageCount: number;
   batchCount: number;
   lastEndCursor: string | null;
-  /** Orgs that block classic-PAT access. Repos in those orgs are skipped. */
-  inaccessibleOrgs: string[];
+  /**
+   * Count of orgs that block classic-PAT access. Repos in those orgs are
+   * skipped. Per session-oracle verdict rule 8: org NAMES are NEVER part
+   * of the public outcome surface (they may identify private/internal
+   * orgs the user has starred). Operator can re-run the fetcher with a
+   * verbose flag against a private artifact if names are needed.
+   */
+  blockedOrgsCount: number;
   /** Non-empty when the fetch could not complete; workflow must hard-fail. */
   partialFailureReason: string;
 };


### PR DESCRIPTION
Fixes the credential-class laundering shipped in #72 and adds the App-mode REST fetch path so \`github_app\` actually owns every role.

Per session-oracle verdict on the previous run, the laundering shape was:

\`\`\`
auth_mode = github_app
star_fetch_auth = pat        <- WRONG: stole PAT under "App mode"
repo_write_auth = github_app
degraded = false             <- LIE
\`\`\`

This PR enforces verdict rules 1-8 in code AND in CI workflow-lint guards.

## Strict 3-mode resolver (commit \`27d21ebe\`)

Three modes only: \`github_app\`, \`pat\`, \`github_token\`. The selected mode owns ALL roles. Type system makes the mixed shape unrepresentable; runtime \`assertNoMixedAuth()\` enforces it.

| Mode            | star_fetch_auth | repo_write_auth | Failure behavior |
|-----------------|-----------------|-----------------|------------------|
| \`github_app\`    | \`github_app\`    | \`github_app\`    | NEVER falls back. Hard-fail. |
| \`pat\`           | \`pat\`           | \`pat\`           | Loud transition to \`effective_mode=github_token\` (configurable, default on) |
| \`github_token\`  | \`github_token\`  | \`github_token\`  | Hard-fail (no further fallback target) |

Fallback is represented as \`effective_mode\` (a new EffectiveAuth with BOTH roles flipped), never hidden role borrowing.

## App-mode REST fetch path (commit \`4d9053f4\`)

GraphQL \`viewer.starredRepositories\` is user-context only — App installation tokens can't call it. Direct evidence from \`refs/github/docs/src/rest/data/fpt-2026-03-10/activity.json\`:

| Endpoint | progAccess.serverToServer | Notes |
|---|---|---|
| \`GET /user/starred\` | **false** | installation token CANNOT call |
| \`GET /users/{username}/starred\` | **true** | installation token CAN call |
| GraphQL \`repository(owner, name)\` | **true** | (used in stage 2) |

So the fetcher branches on selected_mode:

- **github_app**: stage 1 = REST \`/users/{starSourceUser}/starred\` (paginated, \`application/vnd.github.star+json\` Accept header for the \`starred_at\` timestamp). Stage 2 = existing aliased \`repository(...)\` GraphQL batches.
- **pat / github_token**: stage 1 = existing GraphQL \`viewer.starredRepositories\`. Stage 2 same.

App does everything. No PAT borrow. No mixing.

## CI guards

\`00-ci.yml\` workflow-lint job now rejects:

- \`secrets.STARS_TOKEN || secrets.GITHUB_TOKEN\` (the original laundering shape)
- \`steps.app-token.outputs.token || secrets.<anything>\` (App-token-or-PAT fallthrough)
- \`blocked_orgs:\` step output / \`BLOCKED_ORGS:\` env (rule 8: no private org NAMES in public outputs; \`blocked_orgs_count\` only)

## Direct-evidence proof

### \`pnpm gate\` PASS (10 test files, 86 tests, ~5s)

\`\`\`
PASS  typecheck                   ~2s
PASS  test                        ~1.5s   86 tests, 10 files
PASS  validate (taxonomy + schema)  ~0.7s   2,612 repos
PASS  generated-artifacts registry   0ms
PASS  actionlint (workflow YAML)   ~0.6s
gate: PASS
\`\`\`

### Live App-mode fetch verified locally

\`\`\`
SELECTED_MODE=github_app STAR_SOURCE_USER=primeinc node src/fetch/cli.ts
-> 2,612 repos in 7m13s (27 list pages via REST + 105 metadata batches via GraphQL)
-> byte-set parity with the GraphQL path: app-only=0, gql-only=0
\`\`\`

### setup-doctor under production-shape env (App + PAT both present)

\`\`\`json
{ \"selected_mode\": \"github_app\",
  \"star_fetch_auth\": \"github_app\",
  \"repo_write_auth\": \"github_app\",
  \"pat_fallback_to_github_token\": false,
  \"degraded\": false,
  \"reason\": \"auto: GitHub App credentials present and github_app_supports_fetch=true\" }
\`\`\`

### Mandatory test table from the verdict — all green

| Test | Result |
|---|---|
| App configured + PAT configured → selected=github_app, no PAT reference | PASS |
| App configured + App fetch fails | hard-fail by default (PASS) |
| PAT configured + PAT succeeds | PAT does both roles (PASS) |
| PAT configured + PAT expired + fallback enabled | loud transition to github_token (PASS) |
| PAT configured + fallback disabled | hard-fail (PASS) |
| No App/PAT, only GITHUB_TOKEN | github_token, degraded=true (PASS) |
| Mixed role auth emitted | runtime guard throws (PASS) |
| Public log/artifact leaks blocked-org names | CI workflow-lint rejects (PASS) |

## What did NOT change

- 03-classify, 04-build-site, 05-generate-readmes — they still use \`github-actions[bot]\` for commits. Switching them to App-token commits is a follow-up; not in scope here.
- pat-mode behavior (full GraphQL stage 1+2). Unchanged.
- 5% destructive-deletion guard, partial-graphql handling, retry policy.

## After merge

The daily cron will use \`selected_mode=github_app\` end-to-end (REST fetch + App-token commit) once the PR lands. No \`GITHUB_APP_SUPPORTS_FETCH\` variable to flip — defaults to true now that the path is implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)